### PR TITLE
Add project and employee models

### DIFF
--- a/AdministradorProyectosTP/README
+++ b/AdministradorProyectosTP/README
@@ -5,6 +5,8 @@ Tema elegido: Administración de proyectos (Tema 7)
 Alcance de esta entrega:
 
 CRUD completo de Tarea (alta, baja, modificación, consulta, listado)
+CRUD de Proyecto y Empleado
+Las tareas se vinculan a un proyecto y un empleado con costo por hora
 
 Arquitectura en tres capas: UI → Service → DAO
 

--- a/AdministradorProyectosTP/src/dao/EmpleadoDAO.java
+++ b/AdministradorProyectosTP/src/dao/EmpleadoDAO.java
@@ -1,0 +1,13 @@
+package dao;
+
+import model.Empleado;
+import java.util.List;
+import java.util.Optional;
+
+public interface EmpleadoDAO {
+    void crear(Empleado empleado) throws DAOException;
+    void actualizar(Empleado empleado) throws DAOException;
+    void eliminar(int id) throws DAOException;
+    List<Empleado> obtenerTodas() throws DAOException;
+    Optional<Empleado> obtenerPorId(int id) throws DAOException;
+}

--- a/AdministradorProyectosTP/src/dao/InMemoryEmpleadoDAO.java
+++ b/AdministradorProyectosTP/src/dao/InMemoryEmpleadoDAO.java
@@ -1,0 +1,59 @@
+package dao;
+
+import model.Empleado;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public final class InMemoryEmpleadoDAO implements EmpleadoDAO {
+
+    private final List<Empleado> empleados = new CopyOnWriteArrayList<>();
+    private final AtomicInteger nextId = new AtomicInteger(1);
+
+    @Override
+    public void crear(Empleado empleado) throws DAOException {
+        try {
+            empleado.setId(nextId.getAndIncrement());
+            empleados.add(empleado);
+        } catch (Exception e) {
+            throw new DAOException("Error al crear empleado en memoria", e);
+        }
+    }
+
+    @Override
+    public void actualizar(Empleado empleado) throws DAOException {
+        try {
+            empleados.replaceAll(p -> p.getId() == empleado.getId() ? empleado : p);
+        } catch (Exception e) {
+            throw new DAOException("Error al actualizar empleado en memoria", e);
+        }
+    }
+
+    @Override
+    public void eliminar(int id) throws DAOException {
+        try {
+            empleados.removeIf(p -> p.getId() == id);
+        } catch (Exception e) {
+            throw new DAOException("Error al eliminar empleado en memoria", e);
+        }
+    }
+
+    @Override
+    public List<Empleado> obtenerTodas() throws DAOException {
+        try {
+            return List.copyOf(empleados);
+        } catch (Exception e) {
+            throw new DAOException("Error al listar empleados en memoria", e);
+        }
+    }
+
+    @Override
+    public Optional<Empleado> obtenerPorId(int id) throws DAOException {
+        try {
+            return empleados.stream().filter(p -> p.getId() == id).findFirst();
+        } catch (Exception e) {
+            throw new DAOException("Error al buscar empleado en memoria", e);
+        }
+    }
+}

--- a/AdministradorProyectosTP/src/dao/InMemoryProyectoDAO.java
+++ b/AdministradorProyectosTP/src/dao/InMemoryProyectoDAO.java
@@ -1,0 +1,59 @@
+package dao;
+
+import model.Proyecto;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public final class InMemoryProyectoDAO implements ProyectoDAO {
+
+    private final List<Proyecto> proyectos = new CopyOnWriteArrayList<>();
+    private final AtomicInteger nextId = new AtomicInteger(1);
+
+    @Override
+    public void crear(Proyecto proyecto) throws DAOException {
+        try {
+            proyecto.setId(nextId.getAndIncrement());
+            proyectos.add(proyecto);
+        } catch (Exception e) {
+            throw new DAOException("Error al crear proyecto en memoria", e);
+        }
+    }
+
+    @Override
+    public void actualizar(Proyecto proyecto) throws DAOException {
+        try {
+            proyectos.replaceAll(p -> p.getId() == proyecto.getId() ? proyecto : p);
+        } catch (Exception e) {
+            throw new DAOException("Error al actualizar proyecto en memoria", e);
+        }
+    }
+
+    @Override
+    public void eliminar(int id) throws DAOException {
+        try {
+            proyectos.removeIf(p -> p.getId() == id);
+        } catch (Exception e) {
+            throw new DAOException("Error al eliminar proyecto en memoria", e);
+        }
+    }
+
+    @Override
+    public List<Proyecto> obtenerTodas() throws DAOException {
+        try {
+            return List.copyOf(proyectos);
+        } catch (Exception e) {
+            throw new DAOException("Error al listar proyectos en memoria", e);
+        }
+    }
+
+    @Override
+    public Optional<Proyecto> obtenerPorId(int id) throws DAOException {
+        try {
+            return proyectos.stream().filter(p -> p.getId() == id).findFirst();
+        } catch (Exception e) {
+            throw new DAOException("Error al buscar proyecto en memoria", e);
+        }
+    }
+}

--- a/AdministradorProyectosTP/src/dao/ProyectoDAO.java
+++ b/AdministradorProyectosTP/src/dao/ProyectoDAO.java
@@ -1,0 +1,13 @@
+package dao;
+
+import model.Proyecto;
+import java.util.List;
+import java.util.Optional;
+
+public interface ProyectoDAO {
+    void crear(Proyecto proyecto) throws DAOException;
+    void actualizar(Proyecto proyecto) throws DAOException;
+    void eliminar(int id) throws DAOException;
+    List<Proyecto> obtenerTodas() throws DAOException;
+    Optional<Proyecto> obtenerPorId(int id) throws DAOException;
+}

--- a/AdministradorProyectosTP/src/dao/jdbc/JdbcEmpleadoDAO.java
+++ b/AdministradorProyectosTP/src/dao/jdbc/JdbcEmpleadoDAO.java
@@ -1,0 +1,110 @@
+package dao.jdbc;
+
+import dao.DAOException;
+import dao.EmpleadoDAO;
+import model.Empleado;
+
+import java.sql.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+public class JdbcEmpleadoDAO implements EmpleadoDAO {
+
+    private final Connection conn;
+
+    public JdbcEmpleadoDAO(Connection conn) throws DAOException {
+        this.conn = conn;
+        try {
+            crearTablaSiNoExiste();
+        } catch (SQLException e) {
+            throw new DAOException("Error al inicializar la tabla «empleado»", e);
+        }
+    }
+
+    @Override
+    public void crear(Empleado e) throws DAOException {
+        String sql = "INSERT INTO empleado(nombre) VALUES (?)";
+        try (PreparedStatement ps = conn.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)) {
+            ps.setString(1, e.getNombre());
+            ps.executeUpdate();
+            try (ResultSet rs = ps.getGeneratedKeys()) {
+                if (rs.next()) {
+                    e.setId(rs.getInt(1));
+                }
+            }
+        } catch (SQLException ex) {
+            throw new DAOException("Error al crear empleado", ex);
+        }
+    }
+
+    @Override
+    public void actualizar(Empleado e) throws DAOException {
+        String sql = "UPDATE empleado SET nombre=? WHERE id=?";
+        try (PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setString(1, e.getNombre());
+            ps.setInt(2, e.getId());
+            ps.executeUpdate();
+        } catch (SQLException ex) {
+            throw new DAOException("Error al actualizar empleado", ex);
+        }
+    }
+
+    @Override
+    public void eliminar(int id) throws DAOException {
+        try (PreparedStatement ps = conn.prepareStatement("DELETE FROM empleado WHERE id=?")) {
+            ps.setInt(1, id);
+            ps.executeUpdate();
+        } catch (SQLException ex) {
+            throw new DAOException("Error al eliminar empleado", ex);
+        }
+    }
+
+    @Override
+    public List<Empleado> obtenerTodas() throws DAOException {
+        List<Empleado> lista = new ArrayList<>();
+        try (Statement st = conn.createStatement();
+             ResultSet rs = st.executeQuery("SELECT * FROM empleado")) {
+            while (rs.next()) {
+                lista.add(mapRow(rs));
+            }
+        } catch (SQLException ex) {
+            throw new DAOException("Error al listar empleados", ex);
+        }
+        return lista;
+    }
+
+    @Override
+    public Optional<Empleado> obtenerPorId(int id) throws DAOException {
+        try (PreparedStatement ps = conn.prepareStatement("SELECT * FROM empleado WHERE id=?")) {
+            ps.setInt(1, id);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    return Optional.of(mapRow(rs));
+                }
+            }
+        } catch (SQLException ex) {
+            throw new DAOException("Error al buscar empleado", ex);
+        }
+        return Optional.empty();
+    }
+
+    private void crearTablaSiNoExiste() throws SQLException {
+        String ddl = """
+            CREATE TABLE IF NOT EXISTS empleado (
+                id INT AUTO_INCREMENT PRIMARY KEY,
+                nombre VARCHAR(255) NOT NULL
+            )
+        """;
+        try (Statement st = conn.createStatement()) {
+            st.executeUpdate(ddl);
+        }
+    }
+
+    private Empleado mapRow(ResultSet rs) throws SQLException {
+        return new Empleado(
+                rs.getInt("id"),
+                rs.getString("nombre")
+        );
+    }
+}

--- a/AdministradorProyectosTP/src/dao/jdbc/JdbcProyectoDAO.java
+++ b/AdministradorProyectosTP/src/dao/jdbc/JdbcProyectoDAO.java
@@ -1,0 +1,110 @@
+package dao.jdbc;
+
+import dao.DAOException;
+import dao.ProyectoDAO;
+import model.Proyecto;
+
+import java.sql.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+public class JdbcProyectoDAO implements ProyectoDAO {
+
+    private final Connection conn;
+
+    public JdbcProyectoDAO(Connection conn) throws DAOException {
+        this.conn = conn;
+        try {
+            crearTablaSiNoExiste();
+        } catch (SQLException e) {
+            throw new DAOException("Error al inicializar la tabla «proyecto»", e);
+        }
+    }
+
+    @Override
+    public void crear(Proyecto p) throws DAOException {
+        String sql = "INSERT INTO proyecto(nombre) VALUES (?)";
+        try (PreparedStatement ps = conn.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)) {
+            ps.setString(1, p.getNombre());
+            ps.executeUpdate();
+            try (ResultSet rs = ps.getGeneratedKeys()) {
+                if (rs.next()) {
+                    p.setId(rs.getInt(1));
+                }
+            }
+        } catch (SQLException e) {
+            throw new DAOException("Error al crear proyecto", e);
+        }
+    }
+
+    @Override
+    public void actualizar(Proyecto p) throws DAOException {
+        String sql = "UPDATE proyecto SET nombre=? WHERE id=?";
+        try (PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setString(1, p.getNombre());
+            ps.setInt(2, p.getId());
+            ps.executeUpdate();
+        } catch (SQLException e) {
+            throw new DAOException("Error al actualizar proyecto", e);
+        }
+    }
+
+    @Override
+    public void eliminar(int id) throws DAOException {
+        try (PreparedStatement ps = conn.prepareStatement("DELETE FROM proyecto WHERE id=?")) {
+            ps.setInt(1, id);
+            ps.executeUpdate();
+        } catch (SQLException e) {
+            throw new DAOException("Error al eliminar proyecto", e);
+        }
+    }
+
+    @Override
+    public List<Proyecto> obtenerTodas() throws DAOException {
+        List<Proyecto> lista = new ArrayList<>();
+        try (Statement st = conn.createStatement();
+             ResultSet rs = st.executeQuery("SELECT * FROM proyecto")) {
+            while (rs.next()) {
+                lista.add(mapRow(rs));
+            }
+        } catch (SQLException e) {
+            throw new DAOException("Error al listar proyectos", e);
+        }
+        return lista;
+    }
+
+    @Override
+    public Optional<Proyecto> obtenerPorId(int id) throws DAOException {
+        try (PreparedStatement ps = conn.prepareStatement("SELECT * FROM proyecto WHERE id=?")) {
+            ps.setInt(1, id);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    return Optional.of(mapRow(rs));
+                }
+            }
+        } catch (SQLException e) {
+            throw new DAOException("Error al buscar proyecto", e);
+        }
+        return Optional.empty();
+    }
+
+    private void crearTablaSiNoExiste() throws SQLException {
+        String ddl = """
+            CREATE TABLE IF NOT EXISTS proyecto (
+                id INT AUTO_INCREMENT PRIMARY KEY,
+                nombre VARCHAR(255) NOT NULL
+            )
+        """;
+        try (Statement st = conn.createStatement()) {
+            st.executeUpdate(ddl);
+        }
+    }
+
+    private Proyecto mapRow(ResultSet rs) throws SQLException {
+        return new Proyecto(
+                rs.getInt("id"),
+                rs.getString("nombre")
+        );
+    }
+}

--- a/AdministradorProyectosTP/src/dao/jdbc/JdbcTareaDAO.java
+++ b/AdministradorProyectosTP/src/dao/jdbc/JdbcTareaDAO.java
@@ -23,12 +23,16 @@ public class JdbcTareaDAO implements TareaDAO {
     }
     @Override
     public void crear(Tarea t) throws DAOException {
-        String sql = "INSERT INTO tarea(titulo, descripcion, horas_est, horas_real) VALUES (?, ?, ?, ?)";
+        String sql = "INSERT INTO tarea(titulo, descripcion, horas_est, horas_real, proyecto_id, empleado_id, costo_hora) " +
+                     "VALUES (?, ?, ?, ?, ?, ?, ?)";
         try (PreparedStatement ps = conn.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)) {
             ps.setString(1, t.getTitulo());
             ps.setString(2, t.getDescripcion());
             ps.setInt(3, t.getHorasEstimadas());
             ps.setInt(4, t.getHorasReales());
+            ps.setInt(5, t.getProyectoId());
+            ps.setInt(6, t.getEmpleadoId());
+            ps.setInt(7, t.getCostoHora());
             ps.executeUpdate();
 
             try (ResultSet rs = ps.getGeneratedKeys()) {
@@ -43,13 +47,17 @@ public class JdbcTareaDAO implements TareaDAO {
 
     @Override
     public void actualizar(Tarea t) throws DAOException {
-        String sql = "UPDATE tarea SET titulo=?, descripcion=?, horas_est=?, horas_real=? WHERE id=?";
+        String sql = "UPDATE tarea SET titulo=?, descripcion=?, horas_est=?, horas_real=?, " +
+                     "proyecto_id=?, empleado_id=?, costo_hora=? WHERE id=?";
         try (PreparedStatement ps = conn.prepareStatement(sql)) {
             ps.setString(1, t.getTitulo());
             ps.setString(2, t.getDescripcion());
             ps.setInt(3, t.getHorasEstimadas());
             ps.setInt(4, t.getHorasReales());
-            ps.setInt(5, t.getId());
+            ps.setInt(5, t.getProyectoId());
+            ps.setInt(6, t.getEmpleadoId());
+            ps.setInt(7, t.getCostoHora());
+            ps.setInt(8, t.getId());
             ps.executeUpdate();
         } catch (SQLException e) {
             throw new DAOException("Error al actualizar tarea", e);
@@ -102,7 +110,10 @@ public class JdbcTareaDAO implements TareaDAO {
                 titulo VARCHAR(255) NOT NULL,
                 descripcion VARCHAR(1024),
                 horas_est INT,
-                horas_real INT
+                horas_real INT,
+                proyecto_id INT,
+                empleado_id INT,
+                costo_hora INT
             )
         """;
         try (Statement st = conn.createStatement()) {
@@ -116,7 +127,10 @@ public class JdbcTareaDAO implements TareaDAO {
                 rs.getString("titulo"),
                 rs.getString("descripcion"),
                 rs.getInt("horas_est"),
-                rs.getInt("horas_real")
+                rs.getInt("horas_real"),
+                rs.getInt("proyecto_id"),
+                rs.getInt("empleado_id"),
+                rs.getInt("costo_hora")
         );
     }
 }

--- a/AdministradorProyectosTP/src/main/Main.java
+++ b/AdministradorProyectosTP/src/main/Main.java
@@ -2,10 +2,20 @@ package main;
 
 import app.AppManager;            
 import dao.TareaDAO;
+import dao.ProyectoDAO;
+import dao.EmpleadoDAO;
 import dao.jdbc.JdbcTareaDAO;
+import dao.jdbc.JdbcProyectoDAO;
+import dao.jdbc.JdbcEmpleadoDAO;
 import service.TareaService;
+import service.ProyectoService;
+import service.EmpleadoService;
 import service.TareaServiceImpl;
+import service.ProyectoServiceImpl;
+import service.EmpleadoServiceImpl;
 import ui.TareaPanel;
+import ui.ProyectoPanel;
+import ui.EmpleadoPanel;
 
 import javax.swing.SwingUtilities;
 import java.sql.Connection;
@@ -16,12 +26,18 @@ public class Main {
         Connection c = DriverManager.getConnection(
                 "jdbc:h2:file:./tareas", "sa", "");
 
-        TareaDAO dao      = new JdbcTareaDAO(c);
-        TareaService svc  = new TareaServiceImpl(dao);
+        TareaDAO tareaDao      = new JdbcTareaDAO(c);
+        ProyectoDAO proyectoDao = new JdbcProyectoDAO(c);
+        EmpleadoDAO empleadoDao = new JdbcEmpleadoDAO(c);
+
+        TareaService tareaSvc      = new TareaServiceImpl(tareaDao);
+        ProyectoService projSvc    = new ProyectoServiceImpl(proyectoDao);
+        EmpleadoService empSvc     = new EmpleadoServiceImpl(empleadoDao);
+
         AppManager  mgr   = new AppManager();
 
         SwingUtilities.invokeLater(() ->
-            mgr.mostrar(new TareaPanel(mgr, svc))
+            mgr.mostrar(new TareaPanel(mgr, tareaSvc))
         );
         mgr.start();
     }

--- a/AdministradorProyectosTP/src/model/Empleado.java
+++ b/AdministradorProyectosTP/src/model/Empleado.java
@@ -1,0 +1,21 @@
+package model;
+
+public class Empleado {
+    private int id;
+    private String nombre;
+
+    public Empleado(String nombre) {
+        this(0, nombre);
+    }
+
+    public Empleado(int id, String nombre) {
+        this.id = id;
+        this.nombre = nombre;
+    }
+
+    public int getId() { return id; }
+    public void setId(int id) { this.id = id; }
+
+    public String getNombre() { return nombre; }
+    public void setNombre(String nombre) { this.nombre = nombre; }
+}

--- a/AdministradorProyectosTP/src/model/Proyecto.java
+++ b/AdministradorProyectosTP/src/model/Proyecto.java
@@ -1,0 +1,21 @@
+package model;
+
+public class Proyecto {
+    private int id;
+    private String nombre;
+
+    public Proyecto(String nombre) {
+        this(0, nombre);
+    }
+
+    public Proyecto(int id, String nombre) {
+        this.id = id;
+        this.nombre = nombre;
+    }
+
+    public int getId() { return id; }
+    public void setId(int id) { this.id = id; }
+
+    public String getNombre() { return nombre; }
+    public void setNombre(String nombre) { this.nombre = nombre; }
+}

--- a/AdministradorProyectosTP/src/model/Tarea.java
+++ b/AdministradorProyectosTP/src/model/Tarea.java
@@ -6,18 +6,29 @@ public class Tarea {
     private String descripcion;
     private int horasEstimadas;
     private int horasReales;
+    private int proyectoId;
+    private int empleadoId;
+    private int costoHora;
     
-    public Tarea(String titulo, String descripcion, int horasEstimadas, int horasReales) {
-        this(0, titulo, descripcion, horasEstimadas, horasReales);
+    public Tarea(String titulo, String descripcion,
+                 int horasEstimadas, int horasReales,
+                 int proyectoId, int empleadoId, int costoHora) {
+        this(0, titulo, descripcion, horasEstimadas, horasReales,
+             proyectoId, empleadoId, costoHora);
     }
 
 
-    public Tarea(int id, String titulo, String descripcion, int horasEstimadas, int horasReales) {
+    public Tarea(int id, String titulo, String descripcion,
+                 int horasEstimadas, int horasReales,
+                 int proyectoId, int empleadoId, int costoHora) {
         this.id = id;
         this.titulo = titulo;
         this.descripcion = descripcion;
         this.horasEstimadas = horasEstimadas;
         this.horasReales = horasReales;
+        this.proyectoId = proyectoId;
+        this.empleadoId = empleadoId;
+        this.costoHora = costoHora;
     }
 
     // Getters y Setters
@@ -35,4 +46,13 @@ public class Tarea {
 
     public int getHorasReales() { return horasReales; }
     public void setHorasReales(int horasReales) { this.horasReales = horasReales; }
+
+    public int getProyectoId() { return proyectoId; }
+    public void setProyectoId(int proyectoId) { this.proyectoId = proyectoId; }
+
+    public int getEmpleadoId() { return empleadoId; }
+    public void setEmpleadoId(int empleadoId) { this.empleadoId = empleadoId; }
+
+    public int getCostoHora() { return costoHora; }
+    public void setCostoHora(int costoHora) { this.costoHora = costoHora; }
 }

--- a/AdministradorProyectosTP/src/service/EmpleadoService.java
+++ b/AdministradorProyectosTP/src/service/EmpleadoService.java
@@ -1,0 +1,13 @@
+package service;
+
+import model.Empleado;
+import validacion.ValidacionException;
+import java.util.List;
+
+public interface EmpleadoService {
+    void alta(String nombre) throws ValidacionException, ServiceException;
+    void modificar(int id, String nombre) throws ValidacionException, ServiceException;
+    void baja(int id) throws ServiceException;
+    List<Empleado> listado() throws ServiceException;
+    Empleado consulta(int id) throws ServiceException;
+}

--- a/AdministradorProyectosTP/src/service/EmpleadoServiceImpl.java
+++ b/AdministradorProyectosTP/src/service/EmpleadoServiceImpl.java
@@ -1,0 +1,65 @@
+package service;
+
+import dao.DAOException;
+import dao.EmpleadoDAO;
+import model.Empleado;
+import validacion.ValidacionException;
+import validacion.ValidadorDeErrores;
+
+import java.util.List;
+
+public class EmpleadoServiceImpl implements EmpleadoService {
+
+    private final EmpleadoDAO dao;
+
+    public EmpleadoServiceImpl(EmpleadoDAO dao) {
+        this.dao = dao;
+    }
+
+    @Override
+    public void alta(String nombre) throws ValidacionException, ServiceException {
+        ValidadorDeErrores.textoNoVacio(nombre, "Nombre");
+        try {
+            dao.crear(new Empleado(nombre));
+        } catch (DAOException e) {
+            throw new ServiceException("No se pudo guardar el empleado", e);
+        }
+    }
+
+    @Override
+    public void modificar(int id, String nombre) throws ValidacionException, ServiceException {
+        ValidadorDeErrores.textoNoVacio(nombre, "Nombre");
+        try {
+            dao.actualizar(new Empleado(id, nombre));
+        } catch (DAOException e) {
+            throw new ServiceException("No se pudo actualizar el empleado", e);
+        }
+    }
+
+    @Override
+    public void baja(int id) throws ServiceException {
+        try {
+            dao.eliminar(id);
+        } catch (DAOException e) {
+            throw new ServiceException("No se pudo eliminar el empleado", e);
+        }
+    }
+
+    @Override
+    public List<Empleado> listado() throws ServiceException {
+        try {
+            return dao.obtenerTodas();
+        } catch (DAOException e) {
+            throw new ServiceException("No se pudo obtener el listado", e);
+        }
+    }
+
+    @Override
+    public Empleado consulta(int id) throws ServiceException {
+        try {
+            return dao.obtenerPorId(id).orElse(null);
+        } catch (DAOException e) {
+            throw new ServiceException("No se pudo consultar el empleado", e);
+        }
+    }
+}

--- a/AdministradorProyectosTP/src/service/ProyectoService.java
+++ b/AdministradorProyectosTP/src/service/ProyectoService.java
@@ -1,0 +1,13 @@
+package service;
+
+import model.Proyecto;
+import validacion.ValidacionException;
+import java.util.List;
+
+public interface ProyectoService {
+    void alta(String nombre) throws ValidacionException, ServiceException;
+    void modificar(int id, String nombre) throws ValidacionException, ServiceException;
+    void baja(int id) throws ServiceException;
+    List<Proyecto> listado() throws ServiceException;
+    Proyecto consulta(int id) throws ServiceException;
+}

--- a/AdministradorProyectosTP/src/service/ProyectoServiceImpl.java
+++ b/AdministradorProyectosTP/src/service/ProyectoServiceImpl.java
@@ -1,0 +1,65 @@
+package service;
+
+import dao.DAOException;
+import dao.ProyectoDAO;
+import model.Proyecto;
+import validacion.ValidacionException;
+import validacion.ValidadorDeErrores;
+
+import java.util.List;
+
+public class ProyectoServiceImpl implements ProyectoService {
+
+    private final ProyectoDAO dao;
+
+    public ProyectoServiceImpl(ProyectoDAO dao) {
+        this.dao = dao;
+    }
+
+    @Override
+    public void alta(String nombre) throws ValidacionException, ServiceException {
+        ValidadorDeErrores.textoNoVacio(nombre, "Nombre");
+        try {
+            dao.crear(new Proyecto(nombre));
+        } catch (DAOException e) {
+            throw new ServiceException("No se pudo guardar el proyecto", e);
+        }
+    }
+
+    @Override
+    public void modificar(int id, String nombre) throws ValidacionException, ServiceException {
+        ValidadorDeErrores.textoNoVacio(nombre, "Nombre");
+        try {
+            dao.actualizar(new Proyecto(id, nombre));
+        } catch (DAOException e) {
+            throw new ServiceException("No se pudo actualizar el proyecto", e);
+        }
+    }
+
+    @Override
+    public void baja(int id) throws ServiceException {
+        try {
+            dao.eliminar(id);
+        } catch (DAOException e) {
+            throw new ServiceException("No se pudo eliminar el proyecto", e);
+        }
+    }
+
+    @Override
+    public List<Proyecto> listado() throws ServiceException {
+        try {
+            return dao.obtenerTodas();
+        } catch (DAOException e) {
+            throw new ServiceException("No se pudo obtener el listado", e);
+        }
+    }
+
+    @Override
+    public Proyecto consulta(int id) throws ServiceException {
+        try {
+            return dao.obtenerPorId(id).orElse(null);
+        } catch (DAOException e) {
+            throw new ServiceException("No se pudo consultar el proyecto", e);
+        }
+    }
+}

--- a/AdministradorProyectosTP/src/service/TareaService.java
+++ b/AdministradorProyectosTP/src/service/TareaService.java
@@ -6,10 +6,12 @@ import java.util.List;
 
 public interface TareaService {
 
-    void alta(String titulo, String desc, int hEst, int hReal)
+    void alta(String titulo, String desc, int hEst, int hReal,
+              int proyectoId, int empleadoId, int costoHora)
             throws ValidacionException, ServiceException;
 
-    void modificar(int id, String titulo, String desc, int hEst, int hReal)
+    void modificar(int id, String titulo, String desc, int hEst, int hReal,
+                   int proyectoId, int empleadoId, int costoHora)
             throws ValidacionException, ServiceException;
 
     void baja(int id)                      throws ServiceException;

--- a/AdministradorProyectosTP/src/service/TareaServiceImpl.java
+++ b/AdministradorProyectosTP/src/service/TareaServiceImpl.java
@@ -19,24 +19,28 @@ public class TareaServiceImpl implements TareaService {
     // ------------------------------------ CRUD
 
     @Override
-    public void alta(String titulo, String desc, int hEst, int hReal)
+    public void alta(String titulo, String desc, int hEst, int hReal,
+                     int proyectoId, int empleadoId, int costoHora)
             throws ValidacionException, ServiceException {
 
         ValidadorDeErrores.validarTarea(titulo, hEst, hReal);
         try {
-            dao.crear(new Tarea(titulo, desc, hEst, hReal));
+            dao.crear(new Tarea(titulo, desc, hEst, hReal,
+                                proyectoId, empleadoId, costoHora));
         } catch (DAOException ex) {
             throw new ServiceException("No se pudo guardar la tarea", ex);
         }
     }
 
     @Override
-    public void modificar(int id, String titulo, String desc, int hEst, int hReal)
+    public void modificar(int id, String titulo, String desc, int hEst, int hReal,
+                          int proyectoId, int empleadoId, int costoHora)
             throws ValidacionException, ServiceException {
 
         ValidadorDeErrores.validarTarea(titulo, hEst, hReal);
         try {
-            dao.actualizar(new Tarea(id, titulo, desc, hEst, hReal));
+            dao.actualizar(new Tarea(id, titulo, desc, hEst, hReal,
+                                     proyectoId, empleadoId, costoHora));
         } catch (DAOException ex) {
             throw new ServiceException("No se pudo actualizar la tarea", ex);
         }

--- a/AdministradorProyectosTP/src/ui/EmpleadoPanel.java
+++ b/AdministradorProyectosTP/src/ui/EmpleadoPanel.java
@@ -1,0 +1,99 @@
+package ui;
+
+import app.AppManager;
+import service.EmpleadoService;
+import service.ServiceException;
+import ui.componentes.BotoneraPanel;
+import validacion.ValidacionException;
+
+import javax.swing.*;
+import javax.swing.table.DefaultTableModel;
+import java.awt.*;
+import java.util.List;
+
+public class EmpleadoPanel extends JPanel {
+
+    private final AppManager manager;
+    private final EmpleadoService service;
+
+    private final JTable tabla;
+    private final DefaultTableModel modelo;
+
+    public EmpleadoPanel(AppManager manager, EmpleadoService service) {
+        this.manager = manager;
+        this.service = service;
+
+        setLayout(new BorderLayout(10,10));
+
+        modelo = new DefaultTableModel(new Object[]{"ID","Nombre"},0){
+            @Override public boolean isCellEditable(int r,int c){return false;}
+        };
+
+        tabla = new JTable(modelo);
+        add(new JScrollPane(tabla), BorderLayout.CENTER);
+
+        BotoneraPanel botones = new BotoneraPanel(
+                "Agregar","Eliminar","Volver",
+                e->abrirFormulario(null),
+                e->eliminarSeleccionada(),
+                e->manager.mostrar(this)
+        );
+        add(botones, BorderLayout.SOUTH);
+
+        tabla.addMouseListener(new java.awt.event.MouseAdapter(){
+            @Override public void mouseClicked(java.awt.event.MouseEvent e){
+                if(e.getClickCount()==2){
+                    int fila=tabla.getSelectedRow();
+                    if(fila!=-1){
+                        int id=(int)modelo.getValueAt(fila,0);
+                        try{abrirFormulario(service.consulta(id));}
+                        catch(ServiceException se){mostrarError("No se pudo cargar.");}
+                    }
+                }
+            }
+        });
+
+        refrescarTabla();
+    }
+
+    private void mostrarWarn(String m){JOptionPane.showMessageDialog(this,m,"Aviso",JOptionPane.WARNING_MESSAGE);}
+    private void mostrarError(String m){JOptionPane.showMessageDialog(this,m,"Error",JOptionPane.ERROR_MESSAGE);}
+    private void mostrarInfo(String m){JOptionPane.showMessageDialog(this,m,"Info",JOptionPane.INFORMATION_MESSAGE);}
+
+    private void refrescarTabla(){
+        new SwingWorker<List<model.Empleado>,Void>(){
+            @Override protected List<model.Empleado> doInBackground(){
+                try{return service.listado();}catch(ServiceException se){throw new RuntimeException(se);} }
+            @Override protected void done(){
+                try{List<model.Empleado> ps=get();modelo.setRowCount(0);for(model.Empleado p:ps){modelo.addRow(new Object[]{p.getId(),p.getNombre()});}}
+                catch(Exception ex){mostrarError("No se pudo listar.");}
+            }
+        }.execute();
+    }
+
+    private void eliminarSeleccionada(){
+        int fila=tabla.getSelectedRow();
+        if(fila==-1){mostrarWarn("Seleccioná un empleado.");return;}
+        if(JOptionPane.showConfirmDialog(this,"¿Seguro?","Confirmación",JOptionPane.YES_NO_OPTION)==JOptionPane.YES_OPTION){
+            int id=(int)modelo.getValueAt(fila,0);
+            try{service.baja(id);refrescarTabla();mostrarInfo("Empleado eliminado.");}
+            catch(ServiceException se){mostrarError("No se pudo eliminar.");}
+        }
+    }
+
+    private void abrirFormulario(model.Empleado existente){
+        JTextField nombreTxt=new JTextField();
+        if(existente!=null){nombreTxt.setText(existente.getNombre());}
+        JPanel form=new JPanel(new GridLayout(0,2,5,5));
+        form.add(new JLabel("Nombre:"));form.add(nombreTxt);
+
+        int res=JOptionPane.showConfirmDialog(this,form,existente==null?"Agregar empleado":"Editar empleado",JOptionPane.OK_CANCEL_OPTION);
+        if(res==JOptionPane.OK_OPTION){
+            try{
+                String nombre=nombreTxt.getText();
+                if(existente==null){service.alta(nombre);}else{service.modificar(existente.getId(),nombre);}refrescarTabla();
+            }catch(ValidacionException ve){mostrarWarn(ve.getMessage());}
+            catch(ServiceException se){mostrarError("No se pudo guardar.");}
+        }
+    }
+}

--- a/AdministradorProyectosTP/src/ui/ProyectoPanel.java
+++ b/AdministradorProyectosTP/src/ui/ProyectoPanel.java
@@ -1,0 +1,99 @@
+package ui;
+
+import app.AppManager;
+import service.ProyectoService;
+import service.ServiceException;
+import ui.componentes.BotoneraPanel;
+import validacion.ValidacionException;
+
+import javax.swing.*;
+import javax.swing.table.DefaultTableModel;
+import java.awt.*;
+import java.util.List;
+
+public class ProyectoPanel extends JPanel {
+
+    private final AppManager manager;
+    private final ProyectoService service;
+
+    private final JTable tabla;
+    private final DefaultTableModel modelo;
+
+    public ProyectoPanel(AppManager manager, ProyectoService service) {
+        this.manager = manager;
+        this.service = service;
+
+        setLayout(new BorderLayout(10,10));
+
+        modelo = new DefaultTableModel(new Object[]{"ID","Nombre"},0){
+            @Override public boolean isCellEditable(int r,int c){return false;}
+        };
+
+        tabla = new JTable(modelo);
+        add(new JScrollPane(tabla), BorderLayout.CENTER);
+
+        BotoneraPanel botones = new BotoneraPanel(
+                "Agregar","Eliminar","Volver",
+                e->abrirFormulario(null),
+                e->eliminarSeleccionada(),
+                e->manager.mostrar(this)
+        );
+        add(botones, BorderLayout.SOUTH);
+
+        tabla.addMouseListener(new java.awt.event.MouseAdapter(){
+            @Override public void mouseClicked(java.awt.event.MouseEvent e){
+                if(e.getClickCount()==2){
+                    int fila=tabla.getSelectedRow();
+                    if(fila!=-1){
+                        int id=(int)modelo.getValueAt(fila,0);
+                        try{abrirFormulario(service.consulta(id));}
+                        catch(ServiceException se){mostrarError("No se pudo cargar.");}
+                    }
+                }
+            }
+        });
+
+        refrescarTabla();
+    }
+
+    private void mostrarWarn(String m){JOptionPane.showMessageDialog(this,m,"Aviso",JOptionPane.WARNING_MESSAGE);}
+    private void mostrarError(String m){JOptionPane.showMessageDialog(this,m,"Error",JOptionPane.ERROR_MESSAGE);}
+    private void mostrarInfo(String m){JOptionPane.showMessageDialog(this,m,"Info",JOptionPane.INFORMATION_MESSAGE);}
+
+    private void refrescarTabla(){
+        new SwingWorker<List<model.Proyecto>,Void>(){
+            @Override protected List<model.Proyecto> doInBackground(){
+                try{return service.listado();}catch(ServiceException se){throw new RuntimeException(se);} }
+            @Override protected void done(){
+                try{List<model.Proyecto> ps=get();modelo.setRowCount(0);for(model.Proyecto p:ps){modelo.addRow(new Object[]{p.getId(),p.getNombre()});}}
+                catch(Exception ex){mostrarError("No se pudo listar.");}
+            }
+        }.execute();
+    }
+
+    private void eliminarSeleccionada(){
+        int fila=tabla.getSelectedRow();
+        if(fila==-1){mostrarWarn("Seleccioná un proyecto.");return;}
+        if(JOptionPane.showConfirmDialog(this,"¿Seguro?","Confirmación",JOptionPane.YES_NO_OPTION)==JOptionPane.YES_OPTION){
+            int id=(int)modelo.getValueAt(fila,0);
+            try{service.baja(id);refrescarTabla();mostrarInfo("Proyecto eliminado.");}
+            catch(ServiceException se){mostrarError("No se pudo eliminar.");}
+        }
+    }
+
+    private void abrirFormulario(model.Proyecto existente){
+        JTextField nombreTxt=new JTextField();
+        if(existente!=null){nombreTxt.setText(existente.getNombre());}
+        JPanel form=new JPanel(new GridLayout(0,2,5,5));
+        form.add(new JLabel("Nombre:"));form.add(nombreTxt);
+
+        int res=JOptionPane.showConfirmDialog(this,form,existente==null?"Agregar proyecto":"Editar proyecto",JOptionPane.OK_CANCEL_OPTION);
+        if(res==JOptionPane.OK_OPTION){
+            try{
+                String nombre=nombreTxt.getText();
+                if(existente==null){service.alta(nombre);}else{service.modificar(existente.getId(),nombre);}refrescarTabla();
+            }catch(ValidacionException ve){mostrarWarn(ve.getMessage());}
+            catch(ServiceException se){mostrarError("No se pudo guardar.");}
+        }
+    }
+}

--- a/AdministradorProyectosTP/src/ui/TareaPanel.java
+++ b/AdministradorProyectosTP/src/ui/TareaPanel.java
@@ -27,7 +27,7 @@ public class TareaPanel extends JPanel {
         setLayout(new BorderLayout(10, 10));
 
         modelo = new DefaultTableModel(
-                new Object[]{"ID", "Título", "Horas Est.", "Horas Reales"}, 0) {
+                new Object[]{"ID", "Título", "Horas Est.", "Horas Reales", "Proyecto", "Empleado", "Costo"}, 0) {
             @Override public boolean isCellEditable(int r, int c) { return false; }
         };
 
@@ -91,7 +91,8 @@ public class TareaPanel extends JPanel {
                     for (model.Tarea t : tareas) {
                         modelo.addRow(new Object[]{
                                 t.getId(), t.getTitulo(),
-                                t.getHorasEstimadas(), t.getHorasReales()
+                                t.getHorasEstimadas(), t.getHorasReales(),
+                                t.getProyectoId(), t.getEmpleadoId(), t.getCostoHora()
                         });
                     }
                 } catch (Exception ex) {
@@ -129,12 +130,18 @@ public class TareaPanel extends JPanel {
         JTextField descTxt   = new JTextField();
         JTextField estTxt    = new JTextField();
         JTextField realTxt   = new JTextField();
+        JTextField proyectoTxt = new JTextField();
+        JTextField empleadoTxt = new JTextField();
+        JTextField costoTxt    = new JTextField();
 
         if (existente != null) {
             tituloTxt.setText(existente.getTitulo());
             descTxt.setText(existente.getDescripcion());
             estTxt.setText(String.valueOf(existente.getHorasEstimadas()));
             realTxt.setText(String.valueOf(existente.getHorasReales()));
+            proyectoTxt.setText(String.valueOf(existente.getProyectoId()));
+            empleadoTxt.setText(String.valueOf(existente.getEmpleadoId()));
+            costoTxt.setText(String.valueOf(existente.getCostoHora()));
         }
 
         JPanel form = new JPanel(new GridLayout(0, 2, 5, 5));
@@ -142,6 +149,9 @@ public class TareaPanel extends JPanel {
         form.add(new JLabel("Descripción:"));     form.add(descTxt);
         form.add(new JLabel("Horas Estimadas:")); form.add(estTxt);
         form.add(new JLabel("Horas Reales:"));    form.add(realTxt);
+        form.add(new JLabel("Proyecto ID:"));    form.add(proyectoTxt);
+        form.add(new JLabel("Empleado ID:"));    form.add(empleadoTxt);
+        form.add(new JLabel("Costo Hora:"));     form.add(costoTxt);
 
         int res = JOptionPane.showConfirmDialog(
                 this, form,
@@ -154,11 +164,15 @@ public class TareaPanel extends JPanel {
                 String desc   = descTxt.getText();
                 int est       = Integer.parseInt(estTxt.getText());
                 int real      = Integer.parseInt(realTxt.getText());
+                int proyecto  = Integer.parseInt(proyectoTxt.getText());
+                int empleado  = Integer.parseInt(empleadoTxt.getText());
+                int costo     = Integer.parseInt(costoTxt.getText());
 
                 if (existente == null) {
-                    service.alta(titulo, desc, est, real);
+                    service.alta(titulo, desc, est, real, proyecto, empleado, costo);
                 } else {
-                    service.modificar(existente.getId(), titulo, desc, est, real);
+                    service.modificar(existente.getId(), titulo, desc, est, real,
+                                      proyecto, empleado, costo);
                 }
                 refrescarTabla();
 


### PR DESCRIPTION
## Summary
- define `Proyecto` and `Empleado` models
- add DAO interfaces and JDBC/InMemory implementations
- implement services for the new models
- extend `Tarea` to include project, employee and hourly cost
- update `JdbcTareaDAO` schema and queries
- support the new fields in services and `TareaPanel`
- provide simple `ProyectoPanel` and `EmpleadoPanel`
- adjust `Main` and README accordingly

## Testing
- `javac $(find AdministradorProyectosTP/src -name '*.java')`

------
https://chatgpt.com/codex/tasks/task_e_68530a35aed483338d55095931c4808a