### PR TITLE
Implement Kanban board with new task fields

### DIFF
--- a/AdministradorProyectosTP/README
+++ b/AdministradorProyectosTP/README
@@ -6,6 +6,10 @@ Alcance de esta entrega:
 
 CRUD completo de Tarea (alta, baja, modificación, consulta, listado)
 
+Se añadieron campos de inicio y fin de sprint y un estado para cada tarea.
+Se incluyó un tablero Kanban donde es posible mover las tareas entre
+estados mediante doble clic.
+
 Arquitectura en tres capas: UI → Service → DAO
 
 Persistencia JDBC sobre H2

--- a/AdministradorProyectosTP/src/dao/InMemoryTareaDAO.java
+++ b/AdministradorProyectosTP/src/dao/InMemoryTareaDAO.java
@@ -59,4 +59,13 @@ public final class InMemoryTareaDAO implements TareaDAO {
             throw new DAOException("Error al buscar tarea en memoria", e);
         }
     }
+
+    @Override
+    public void actualizarEstado(int id, model.EstadoTarea estado) throws DAOException {
+        try {
+            tareas.forEach(t -> { if (t.getId() == id) t.setEstado(estado); });
+        } catch (Exception e) {
+            throw new DAOException("Error al cambiar estado en memoria", e);
+        }
+    }
 }

--- a/AdministradorProyectosTP/src/dao/TareaDAO.java
+++ b/AdministradorProyectosTP/src/dao/TareaDAO.java
@@ -11,4 +11,5 @@ public interface TareaDAO {
     void eliminar(int id)                     throws DAOException;
     List<Tarea> obtenerTodas()                throws DAOException;
     Optional<Tarea> obtenerPorId(int id)      throws DAOException;
+    void actualizarEstado(int id, model.EstadoTarea estado) throws DAOException;
 }

--- a/AdministradorProyectosTP/src/dao/jdbc/JdbcTareaDAO.java
+++ b/AdministradorProyectosTP/src/dao/jdbc/JdbcTareaDAO.java
@@ -23,12 +23,22 @@ public class JdbcTareaDAO implements TareaDAO {
     }
     @Override
     public void crear(Tarea t) throws DAOException {
-        String sql = "INSERT INTO tarea(titulo, descripcion, horas_est, horas_real) VALUES (?, ?, ?, ?)";
+        String sql = "INSERT INTO tarea(titulo, descripcion, horas_est, horas_real, inicio_sprint, fin_sprint, estado) " +
+                     "VALUES (?, ?, ?, ?, ?, ?, ?)";
         try (PreparedStatement ps = conn.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)) {
             ps.setString(1, t.getTitulo());
             ps.setString(2, t.getDescripcion());
             ps.setInt(3, t.getHorasEstimadas());
             ps.setInt(4, t.getHorasReales());
+            if (t.getInicioSprint() != null)
+                ps.setDate(5, Date.valueOf(t.getInicioSprint()));
+            else
+                ps.setNull(5, Types.DATE);
+            if (t.getFinSprint() != null)
+                ps.setDate(6, Date.valueOf(t.getFinSprint()));
+            else
+                ps.setNull(6, Types.DATE);
+            ps.setString(7, t.getEstado() != null ? t.getEstado().name() : null);
             ps.executeUpdate();
 
             try (ResultSet rs = ps.getGeneratedKeys()) {
@@ -43,16 +53,38 @@ public class JdbcTareaDAO implements TareaDAO {
 
     @Override
     public void actualizar(Tarea t) throws DAOException {
-        String sql = "UPDATE tarea SET titulo=?, descripcion=?, horas_est=?, horas_real=? WHERE id=?";
+        String sql = "UPDATE tarea SET titulo=?, descripcion=?, horas_est=?, horas_real=?, " +
+                     "inicio_sprint=?, fin_sprint=?, estado=? WHERE id=?";
         try (PreparedStatement ps = conn.prepareStatement(sql)) {
             ps.setString(1, t.getTitulo());
             ps.setString(2, t.getDescripcion());
             ps.setInt(3, t.getHorasEstimadas());
             ps.setInt(4, t.getHorasReales());
-            ps.setInt(5, t.getId());
+            if (t.getInicioSprint() != null)
+                ps.setDate(5, Date.valueOf(t.getInicioSprint()));
+            else
+                ps.setNull(5, Types.DATE);
+            if (t.getFinSprint() != null)
+                ps.setDate(6, Date.valueOf(t.getFinSprint()));
+            else
+                ps.setNull(6, Types.DATE);
+            ps.setString(7, t.getEstado() != null ? t.getEstado().name() : null);
+            ps.setInt(8, t.getId());
             ps.executeUpdate();
         } catch (SQLException e) {
             throw new DAOException("Error al actualizar tarea", e);
+        }
+    }
+
+    @Override
+    public void actualizarEstado(int id, model.EstadoTarea estado) throws DAOException {
+        String sql = "UPDATE tarea SET estado=? WHERE id=?";
+        try (PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setString(1, estado.name());
+            ps.setInt(2, id);
+            ps.executeUpdate();
+        } catch (SQLException e) {
+            throw new DAOException("Error al actualizar estado", e);
         }
     }
 
@@ -102,7 +134,10 @@ public class JdbcTareaDAO implements TareaDAO {
                 titulo VARCHAR(255) NOT NULL,
                 descripcion VARCHAR(1024),
                 horas_est INT,
-                horas_real INT
+                horas_real INT,
+                inicio_sprint DATE,
+                fin_sprint DATE,
+                estado VARCHAR(20)
             )
         """;
         try (Statement st = conn.createStatement()) {
@@ -116,7 +151,10 @@ public class JdbcTareaDAO implements TareaDAO {
                 rs.getString("titulo"),
                 rs.getString("descripcion"),
                 rs.getInt("horas_est"),
-                rs.getInt("horas_real")
+                rs.getInt("horas_real"),
+                rs.getDate("inicio_sprint") != null ? rs.getDate("inicio_sprint").toLocalDate() : null,
+                rs.getDate("fin_sprint") != null ? rs.getDate("fin_sprint").toLocalDate() : null,
+                rs.getString("estado") != null ? model.EstadoTarea.valueOf(rs.getString("estado")) : null
         );
     }
 }

--- a/AdministradorProyectosTP/src/model/EstadoTarea.java
+++ b/AdministradorProyectosTP/src/model/EstadoTarea.java
@@ -1,0 +1,7 @@
+package model;
+
+public enum EstadoTarea {
+    BACKLOG,
+    EN_PROGRESO,
+    TERMINADA
+}

--- a/AdministradorProyectosTP/src/model/Tarea.java
+++ b/AdministradorProyectosTP/src/model/Tarea.java
@@ -1,23 +1,38 @@
 package model;
 
+import java.time.LocalDate;
+
+import model.EstadoTarea;
 public class Tarea {
     private int id;
     private String titulo;
     private String descripcion;
     private int horasEstimadas;
     private int horasReales;
+    private LocalDate inicioSprint;
+    private LocalDate finSprint;
+    private EstadoTarea estado;
     
     public Tarea(String titulo, String descripcion, int horasEstimadas, int horasReales) {
-        this(0, titulo, descripcion, horasEstimadas, horasReales);
+        this(0, titulo, descripcion, horasEstimadas, horasReales, null, null, EstadoTarea.BACKLOG);
     }
 
-
     public Tarea(int id, String titulo, String descripcion, int horasEstimadas, int horasReales) {
+        this(id, titulo, descripcion, horasEstimadas, horasReales, null, null, EstadoTarea.BACKLOG);
+    }
+
+    public Tarea(int id, String titulo, String descripcion,
+                 int horasEstimadas, int horasReales,
+                 LocalDate inicioSprint, LocalDate finSprint,
+                 EstadoTarea estado) {
         this.id = id;
         this.titulo = titulo;
         this.descripcion = descripcion;
         this.horasEstimadas = horasEstimadas;
         this.horasReales = horasReales;
+        this.inicioSprint = inicioSprint;
+        this.finSprint = finSprint;
+        this.estado = estado;
     }
 
     // Getters y Setters
@@ -35,4 +50,16 @@ public class Tarea {
 
     public int getHorasReales() { return horasReales; }
     public void setHorasReales(int horasReales) { this.horasReales = horasReales; }
+
+    public LocalDate getInicioSprint() { return inicioSprint; }
+    public void setInicioSprint(LocalDate inicioSprint) { this.inicioSprint = inicioSprint; }
+
+    public LocalDate getFinSprint() { return finSprint; }
+    public void setFinSprint(LocalDate finSprint) { this.finSprint = finSprint; }
+
+    public EstadoTarea getEstado() { return estado; }
+    public void setEstado(EstadoTarea estado) { this.estado = estado; }
+
+    @Override
+    public String toString() { return titulo; }
 }

--- a/AdministradorProyectosTP/src/service/TareaService.java
+++ b/AdministradorProyectosTP/src/service/TareaService.java
@@ -6,11 +6,17 @@ import java.util.List;
 
 public interface TareaService {
 
-    void alta(String titulo, String desc, int hEst, int hReal)
+    void alta(String titulo, String desc, int hEst, int hReal,
+              java.time.LocalDate inicio, java.time.LocalDate fin,
+              model.EstadoTarea estado)
             throws ValidacionException, ServiceException;
 
-    void modificar(int id, String titulo, String desc, int hEst, int hReal)
+    void modificar(int id, String titulo, String desc, int hEst, int hReal,
+                   java.time.LocalDate inicio, java.time.LocalDate fin,
+                   model.EstadoTarea estado)
             throws ValidacionException, ServiceException;
+
+    void cambiarEstado(int id, model.EstadoTarea estado) throws ServiceException;
 
     void baja(int id)                      throws ServiceException;
     List<Tarea> listado()                  throws ServiceException;

--- a/AdministradorProyectosTP/src/service/TareaServiceImpl.java
+++ b/AdministradorProyectosTP/src/service/TareaServiceImpl.java
@@ -19,26 +19,39 @@ public class TareaServiceImpl implements TareaService {
     // ------------------------------------ CRUD
 
     @Override
-    public void alta(String titulo, String desc, int hEst, int hReal)
+    public void alta(String titulo, String desc, int hEst, int hReal,
+                     java.time.LocalDate inicio, java.time.LocalDate fin,
+                     model.EstadoTarea estado)
             throws ValidacionException, ServiceException {
 
         ValidadorDeErrores.validarTarea(titulo, hEst, hReal);
         try {
-            dao.crear(new Tarea(titulo, desc, hEst, hReal));
+            dao.crear(new Tarea(0, titulo, desc, hEst, hReal, inicio, fin, estado));
         } catch (DAOException ex) {
             throw new ServiceException("No se pudo guardar la tarea", ex);
         }
     }
 
     @Override
-    public void modificar(int id, String titulo, String desc, int hEst, int hReal)
+    public void modificar(int id, String titulo, String desc, int hEst, int hReal,
+                          java.time.LocalDate inicio, java.time.LocalDate fin,
+                          model.EstadoTarea estado)
             throws ValidacionException, ServiceException {
 
         ValidadorDeErrores.validarTarea(titulo, hEst, hReal);
         try {
-            dao.actualizar(new Tarea(id, titulo, desc, hEst, hReal));
+            dao.actualizar(new Tarea(id, titulo, desc, hEst, hReal, inicio, fin, estado));
         } catch (DAOException ex) {
             throw new ServiceException("No se pudo actualizar la tarea", ex);
+        }
+    }
+
+    @Override
+    public void cambiarEstado(int id, model.EstadoTarea estado) throws ServiceException {
+        try {
+            dao.actualizarEstado(id, estado);
+        } catch (DAOException ex) {
+            throw new ServiceException("No se pudo cambiar el estado", ex);
         }
     }
 

--- a/AdministradorProyectosTP/src/ui/KanbanPanel.java
+++ b/AdministradorProyectosTP/src/ui/KanbanPanel.java
@@ -1,0 +1,81 @@
+package ui;
+
+import app.AppManager;
+import service.TareaService;
+import service.ServiceException;
+
+import javax.swing.*;
+import java.awt.*;
+import java.util.List;
+
+public class KanbanPanel extends JPanel {
+    private final AppManager manager;
+    private final TareaService service;
+    private final DefaultListModel<model.Tarea> backlogModel = new DefaultListModel<>();
+    private final DefaultListModel<model.Tarea> progresoModel = new DefaultListModel<>();
+    private final DefaultListModel<model.Tarea> doneModel = new DefaultListModel<>();
+
+    public KanbanPanel(AppManager manager, TareaService service) {
+        this.manager = manager;
+        this.service = service;
+        setLayout(new BorderLayout(10,10));
+
+        JPanel board = new JPanel(new GridLayout(1,3,10,10));
+        board.add(createColumn("Backlog", backlogModel));
+        board.add(createColumn("En Progreso", progresoModel));
+        board.add(createColumn("Terminada", doneModel));
+        add(board, BorderLayout.CENTER);
+
+        JButton volver = new JButton("Volver");
+        volver.addActionListener(e -> manager.mostrar(new TareaPanel(manager, service)));
+        add(volver, BorderLayout.SOUTH);
+
+        cargarDatos();
+    }
+
+    private JScrollPane createColumn(String titulo, DefaultListModel<model.Tarea> model) {
+        JList<model.Tarea> list = new JList<>(model);
+        list.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
+        list.addMouseListener(new java.awt.event.MouseAdapter() {
+            @Override public void mouseClicked(java.awt.event.MouseEvent e) {
+                if (e.getClickCount() == 2) {
+                    model.Tarea t = list.getSelectedValue();
+                    if (t != null) moverTarea(t);
+                }
+            }
+        });
+        JPanel panel = new JPanel(new BorderLayout());
+        panel.add(new JLabel(titulo, SwingConstants.CENTER), BorderLayout.NORTH);
+        panel.add(new JScrollPane(list), BorderLayout.CENTER);
+        return new JScrollPane(panel);
+    }
+
+    private void moverTarea(model.Tarea t) {
+        model.EstadoTarea nuevo;
+        if (t.getEstado() == model.EstadoTarea.BACKLOG) nuevo = model.EstadoTarea.EN_PROGRESO;
+        else if (t.getEstado() == model.EstadoTarea.EN_PROGRESO) nuevo = model.EstadoTarea.TERMINADA;
+        else return;
+        try {
+            service.cambiarEstado(t.getId(), nuevo);
+            cargarDatos();
+        } catch (ServiceException ex) {
+            JOptionPane.showMessageDialog(this, "No se pudo mover la tarea", "Error", JOptionPane.ERROR_MESSAGE);
+        }
+    }
+
+    private void cargarDatos() {
+        backlogModel.clear();
+        progresoModel.clear();
+        doneModel.clear();
+        try {
+            List<model.Tarea> tareas = service.listado();
+            for (model.Tarea t : tareas) {
+                if (t.getEstado() == model.EstadoTarea.BACKLOG) backlogModel.addElement(t);
+                else if (t.getEstado() == model.EstadoTarea.EN_PROGRESO) progresoModel.addElement(t);
+                else doneModel.addElement(t);
+            }
+        } catch (ServiceException ex) {
+            JOptionPane.showMessageDialog(this, "No se pudo cargar el tablero", "Error", JOptionPane.ERROR_MESSAGE);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- track sprint start/end and status on tasks
- persist new task fields in JDBC and in-memory DAO implementations
- expose new service methods for updating status
- extend UI with Kanban board and extra task form fields
- document new Kanban feature in README

## Testing
- `javac $(find src -name '*.java')`

------
https://chatgpt.com/codex/tasks/task_e_68530a3742b08333adb1afbf22a22903