### PR TITLE
Update Tarea to reference objects and recalc costs

### DIFF
--- a/AdministradorProyectosTP/src/main/Main.java
+++ b/AdministradorProyectosTP/src/main/Main.java
@@ -22,13 +22,13 @@ public class Main {
         Connection c = DriverManager.getConnection(
                 "jdbc:h2:file:./tareas", "sa", "");
 
-        TareaDAO tareaDao      = new JdbcTareaDAO(c);
         ProyectoDAO proyectoDao = new JdbcProyectoDAO(c);
         EmpleadoDAO empleadoDao = new JdbcEmpleadoDAO(c);
+        TareaDAO tareaDao      = new JdbcTareaDAO(c, proyectoDao, empleadoDao);
         HistorialDAO histDao    = new JdbcHistorialDAO(c);
         AsignacionDAO asigDao   = new JdbcAsignacionDAO(c);
 
-        TareaService tareaSvc      = new TareaServiceImpl(tareaDao, histDao);
+        TareaService tareaSvc      = new TareaServiceImpl(tareaDao, histDao, proyectoDao, empleadoDao);
         ProyectoService projSvc    = new ProyectoServiceImpl(proyectoDao);
         EmpleadoService empSvc     = new EmpleadoServiceImpl(empleadoDao);
         AsignacionService asigSvc  = new AsignacionServiceImpl(asigDao, empleadoDao);

--- a/AdministradorProyectosTP/src/model/Tarea.java
+++ b/AdministradorProyectosTP/src/model/Tarea.java
@@ -2,6 +2,13 @@ package model;
 
 import java.time.LocalDate;
 
+import model.Proyecto;
+import model.Empleado;
+
+/**
+ * Representa una tarea de un proyecto.
+ */
+
 public class Tarea {
     private int id;
     private String titulo;
@@ -12,15 +19,14 @@ public class Tarea {
     private LocalDate finSprint;
     private EstadoTarea estado;
 
-    private int proyectoId;
-    private int empleadoId;
-    private int costoHora;
+    private Proyecto proyecto;
+    private Empleado empleado;
 
     public Tarea(int id, String titulo, String descripcion,
                  int horasEstimadas, int horasReales,
                  LocalDate inicioSprint, LocalDate finSprint,
                  EstadoTarea estado,
-                 int proyectoId, int empleadoId, int costoHora) {
+                 Proyecto proyecto, Empleado empleado) {
         this.id = id;
         this.titulo = titulo;
         this.descripcion = descripcion;
@@ -29,18 +35,17 @@ public class Tarea {
         this.inicioSprint = inicioSprint;
         this.finSprint = finSprint;
         this.estado = estado;
-        this.proyectoId = proyectoId;
-        this.empleadoId = empleadoId;
-        this.costoHora = costoHora;
+        this.proyecto = proyecto;
+        this.empleado = empleado;
     }
 
     public Tarea(String titulo, String descripcion,
                  int horasEstimadas, int horasReales,
                  LocalDate inicioSprint, LocalDate finSprint,
                  EstadoTarea estado,
-                 int proyectoId, int empleadoId, int costoHora) {
+                 Proyecto proyecto, Empleado empleado) {
         this(0, titulo, descripcion, horasEstimadas, horasReales,
-             inicioSprint, finSprint, estado, proyectoId, empleadoId, costoHora);
+             inicioSprint, finSprint, estado, proyecto, empleado);
     }
 
     public int getId() { return id; }
@@ -67,14 +72,15 @@ public class Tarea {
     public EstadoTarea getEstado() { return estado; }
     public void setEstado(EstadoTarea estado) { this.estado = estado; }
 
-    public int getProyectoId() { return proyectoId; }
-    public void setProyectoId(int proyectoId) { this.proyectoId = proyectoId; }
+    public Proyecto getProyecto() { return proyecto; }
+    public void setProyecto(Proyecto proyecto) { this.proyecto = proyecto; }
 
-    public int getEmpleadoId() { return empleadoId; }
-    public void setEmpleadoId(int empleadoId) { this.empleadoId = empleadoId; }
+    public Empleado getEmpleado() { return empleado; }
+    public void setEmpleado(Empleado empleado) { this.empleado = empleado; }
 
-    public int getCostoHora() { return costoHora; }
-    public void setCostoHora(int costoHora) { this.costoHora = costoHora; }
+    public int getCostoHora() {
+        return empleado != null ? empleado.getCostoHora() : 0;
+    }
 
     @Override
     public String toString() {

--- a/AdministradorProyectosTP/src/service/ReporteServiceImpl.java
+++ b/AdministradorProyectosTP/src/service/ReporteServiceImpl.java
@@ -22,9 +22,9 @@ public class ReporteServiceImpl implements ReporteService {
             List<Tarea> tareas = tareaDao.obtenerTodas();
             Map<Integer, CostoProyecto> map = new HashMap<>();
             for (Tarea t : tareas) {
-                CostoProyecto c = map.computeIfAbsent(t.getProyectoId(), k -> new CostoProyecto(k,0,0));
+                CostoProyecto c = map.computeIfAbsent(t.getProyecto().getId(), k -> new CostoProyecto(k,0,0));
                 c.horas += t.getHorasReales();
-                c.costo += t.getHorasReales() * t.getCostoHora();
+                c.costo += t.getHorasReales() * t.getEmpleado().getCostoHora();
             }
             return new ArrayList<>(map.values());
         } catch (DAOException e) {

--- a/AdministradorProyectosTP/src/service/TareaService.java
+++ b/AdministradorProyectosTP/src/service/TareaService.java
@@ -10,12 +10,12 @@ public interface TareaService {
 
     void alta(String titulo, String desc, int hEst, int hReal,
               LocalDate inicio, LocalDate fin, model.EstadoTarea estado,
-              int proyectoId, int empleadoId, int costoHora)
+              int proyectoId, int empleadoId)
             throws ValidacionException, ServiceException;
 
     void modificar(int id, String titulo, String desc, int hEst, int hReal,
                    LocalDate inicio, LocalDate fin, model.EstadoTarea estado,
-                   int proyectoId, int empleadoId, int costoHora)
+                   int proyectoId, int empleadoId)
             throws ValidacionException, ServiceException;
 
     void cambiarEstado(int id, model.EstadoTarea estado) throws ServiceException;

--- a/AdministradorProyectosTP/src/ui/TareaPanel.java
+++ b/AdministradorProyectosTP/src/ui/TareaPanel.java
@@ -97,7 +97,7 @@ public class TareaPanel extends JPanel {
                                 t.getId(), t.getTitulo(),
                                 t.getHorasEstimadas(), t.getHorasReales(),
                                 t.getEstado(),
-                                t.getProyectoId(), t.getEmpleadoId(), t.getCostoHora()
+                                t.getProyecto().getId(), t.getEmpleado().getId(), t.getCostoHora()
                         });
                     }
                 } catch (Exception ex) {
@@ -141,7 +141,6 @@ public class TareaPanel extends JPanel {
 
         JTextField proyectoTxt = new JTextField();
         JTextField empleadoTxt = new JTextField();
-        JTextField costoTxt    = new JTextField();
         JTextArea histArea = new JTextArea();
         histArea.setEditable(false);
 
@@ -157,9 +156,8 @@ public class TareaPanel extends JPanel {
             if (existente.getEstado() != null)
                 estadoBox.setSelectedItem(existente.getEstado());
 
-            proyectoTxt.setText(String.valueOf(existente.getProyectoId()));
-            empleadoTxt.setText(String.valueOf(existente.getEmpleadoId()));
-            costoTxt.setText(String.valueOf(existente.getCostoHora()));
+            proyectoTxt.setText(String.valueOf(existente.getProyecto().getId()));
+            empleadoTxt.setText(String.valueOf(existente.getEmpleado().getId()));
             try {
                 java.util.List<model.HistorialEstado> hs = service.historial(existente.getId());
                 for(model.HistorialEstado h: hs){
@@ -178,7 +176,6 @@ public class TareaPanel extends JPanel {
 
         form.add(new JLabel("Proyecto ID:"));    form.add(proyectoTxt);
         form.add(new JLabel("Empleado ID:"));    form.add(empleadoTxt);
-        form.add(new JLabel("Costo Hora:"));     form.add(costoTxt);
         form.add(new JLabel("Estado:"));         form.add(estadoBox);
         form.add(new JLabel("Historial:"));      form.add(new JScrollPane(histArea));
 
@@ -199,13 +196,12 @@ public class TareaPanel extends JPanel {
 
                 int proyecto  = Integer.parseInt(proyectoTxt.getText());
                 int empleado  = Integer.parseInt(empleadoTxt.getText());
-                int costo     = Integer.parseInt(costoTxt.getText());
 
                 if (existente == null) {
-                    service.alta(titulo, desc, est, real, inicio, fin, estado, proyecto, empleado, costo);
+                    service.alta(titulo, desc, est, real, inicio, fin, estado, proyecto, empleado);
                 } else {
                     service.modificar(existente.getId(), titulo, desc, est, real,
-                                      inicio, fin, estado, proyecto, empleado, costo);
+                                      inicio, fin, estado, proyecto, empleado);
                 }
                 refrescarTabla();
 


### PR DESCRIPTION
## Summary
- refactor `Tarea` to store `Proyecto` and `Empleado`
- adapt JDBC DAO to load/save with object references
- fetch employee rate to compute costs in reports
- update service layer and UI for new model

## Testing
- `javac -d bin $(find src -name "*.java")`

------
https://chatgpt.com/codex/tasks/task_e_685320353bac833392b2cf48b75951a7