### PR TITLE
Fix exception name in README

### DIFF
--- a/AdministradorProyectosTP/README
+++ b/AdministradorProyectosTP/README
@@ -16,7 +16,7 @@ Arquitectura en tres capas: UI → Service → DAO
 
 Persistencia JDBC sobre H2
 
-Manejo de excepciones: ValidacionException y DataAccessException
+Manejo de excepciones: ValidacionException y DAOException
 
 Swing hecho a mano
 


### PR DESCRIPTION
## Summary
- fix mismatch between README and implementation

## Testing
- `javac -d AdministradorProyectosTP/bin $(find AdministradorProyectosTP/src -name "*.java")`
- `java -cp AdministradorProyectosTP/bin main.Main` *(fails: No suitable driver found)*

------
https://chatgpt.com/codex/tasks/task_e_6853232c8a1c8333bd38061f5d88402d