### PR TITLE
Add missing in-memory DAO implementations

### DIFF
--- a/AdministradorProyectosTP/src/dao/InMemoryAsignacionDAO.java
+++ b/AdministradorProyectosTP/src/dao/InMemoryAsignacionDAO.java
@@ -1,0 +1,73 @@
+package dao;
+
+import model.Empleado;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+public final class InMemoryAsignacionDAO implements AsignacionDAO {
+
+    private final Map<Integer, Set<Integer>> asignaciones = new ConcurrentHashMap<>();
+    private final EmpleadoDAO empleadoDao;
+
+    public InMemoryAsignacionDAO(EmpleadoDAO empleadoDao) {
+        this.empleadoDao = empleadoDao;
+    }
+
+    @Override
+    public void asignar(int empleadoId, int proyectoId) throws DAOException {
+        try {
+            asignaciones
+                .computeIfAbsent(proyectoId, k -> ConcurrentHashMap.newKeySet())
+                .add(empleadoId);
+        } catch (Exception e) {
+            throw new DAOException("Error al asignar en memoria", e);
+        }
+    }
+
+    @Override
+    public void desasignar(int empleadoId, int proyectoId) throws DAOException {
+        try {
+            Set<Integer> set = asignaciones.get(proyectoId);
+            if (set != null) {
+                set.remove(empleadoId);
+                if (set.isEmpty()) {
+                    asignaciones.remove(proyectoId);
+                }
+            }
+        } catch (Exception e) {
+            throw new DAOException("Error al desasignar en memoria", e);
+        }
+    }
+
+    @Override
+    public List<Integer> empleadosPorProyecto(int proyectoId) throws DAOException {
+        try {
+            Set<Integer> set = asignaciones.get(proyectoId);
+            if (set == null) return List.of();
+            return new ArrayList<>(set);
+        } catch (Exception e) {
+            throw new DAOException("Error al listar asignados en memoria", e);
+        }
+    }
+
+    @Override
+    public List<Integer> empleadosLibres() throws DAOException {
+        try {
+            List<Integer> todos = empleadoDao.obtenerTodas().stream()
+                    .map(Empleado::getId)
+                    .toList();
+            Set<Integer> asignados = asignaciones.values().stream()
+                    .flatMap(Set::stream)
+                    .collect(java.util.stream.Collectors.toSet());
+            return todos.stream()
+                    .filter(id -> !asignados.contains(id))
+                    .toList();
+        } catch (Exception e) {
+            throw new DAOException("Error al obtener libres en memoria", e);
+        }
+    }
+}

--- a/AdministradorProyectosTP/src/dao/InMemoryHistorialDAO.java
+++ b/AdministradorProyectosTP/src/dao/InMemoryHistorialDAO.java
@@ -1,0 +1,36 @@
+package dao;
+
+import model.HistorialEstado;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public final class InMemoryHistorialDAO implements HistorialDAO {
+
+    private final List<HistorialEstado> historiales = new CopyOnWriteArrayList<>();
+    private final AtomicInteger nextId = new AtomicInteger(1);
+
+    @Override
+    public void registrar(HistorialEstado h) throws DAOException {
+        try {
+            h.setId(nextId.getAndIncrement());
+            historiales.add(h);
+        } catch (Exception e) {
+            throw new DAOException("Error al registrar historial en memoria", e);
+        }
+    }
+
+    @Override
+    public List<HistorialEstado> obtenerPorTarea(int tareaId) throws DAOException {
+        try {
+            return historiales.stream()
+                    .filter(h -> h.getTareaId() == tareaId)
+                    .sorted(Comparator.comparing(HistorialEstado::getFecha))
+                    .toList();
+        } catch (Exception e) {
+            throw new DAOException("Error al listar historial en memoria", e);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement `InMemoryHistorialDAO` to store history entries without JDBC
- implement `InMemoryAsignacionDAO` with constructor dependency on `EmpleadoDAO`

## Testing
- `javac -d ../../bin @sources.txt`

------
https://chatgpt.com/codex/tasks/task_e_685411bd5a888333911f4843a9cea932