### PR TITLE
Improve Eclipse configuration

### DIFF
--- a/AdministradorProyectosTP/.classpath
+++ b/AdministradorProyectosTP/.classpath
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry exported="true" kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-22">
-		<attributes>
-			<attribute name="module" value="true"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="lib" path="C:/Users/simon/Downloads/h2-2.2.224.jar"/>
-	<classpathentry kind="output" path="bin"/>
+       <classpathentry exported="true" kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17">
+               <attributes>
+                       <attribute name="module" value="true"/>
+               </attributes>
+       </classpathentry>
+       <classpathentry kind="src" path="src"/>
+       <classpathentry kind="lib" path="lib/h2.jar"/>
+       <classpathentry kind="output" path="bin"/>
 </classpath>

--- a/AdministradorProyectosTP/.gitignore
+++ b/AdministradorProyectosTP/.gitignore
@@ -1,1 +1,2 @@
 /bin/
+/lib/*.jar

--- a/AdministradorProyectosTP/.settings/org.eclipse.jdt.core.prefs
+++ b/AdministradorProyectosTP/.settings/org.eclipse.jdt.core.prefs
@@ -1,8 +1,8 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=22
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=17
 org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
-org.eclipse.jdt.core.compiler.compliance=22
+org.eclipse.jdt.core.compiler.compliance=17
 org.eclipse.jdt.core.compiler.debug.lineNumber=generate
 org.eclipse.jdt.core.compiler.debug.localVariable=generate
 org.eclipse.jdt.core.compiler.debug.sourceFile=generate
@@ -11,4 +11,4 @@ org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
 org.eclipse.jdt.core.compiler.release=enabled
-org.eclipse.jdt.core.compiler.source=22
+org.eclipse.jdt.core.compiler.source=17

--- a/AdministradorProyectosTP/README
+++ b/AdministradorProyectosTP/README
@@ -62,6 +62,13 @@ Reemplazá `<ruta-h2.jar>` por la ubicación del driver JDBC de H2.
 Se necesita JDK 17 o superior. La aplicación crea automáticamente la base de datos
 "tareas.db" la primera vez.
 
+### Importar en Eclipse
+
+Copiá el driver de H2 en `AdministradorProyectosTP/lib/h2.jar` antes de importar
+el proyecto. Eclipse tomará esa librería mediante el archivo `.classpath` que
+acompaña al repositorio. Seleccioná **File → Import → Existing Projects into
+Workspace** y elegí la carpeta `AdministradorProyectosTP`.
+
 
 Resumen de funcionalidades implementadas:
 


### PR DESCRIPTION
## Summary
- fix `.classpath` to use Java 17 and a relative H2 path
- update Java compiler prefs to 17
- document how to import the project in Eclipse
- ignore jar files in `lib/` and add a placeholder directory

## Testing
- `javac -d bin $(find AdministradorProyectosTP/src -name "*.java")`

------
https://chatgpt.com/codex/tasks/task_e_6875916fc48c8333b2e66fc4834b757b