### PR TITLE
Allow task without employee

### DIFF
--- a/AdministradorProyectosTP/README
+++ b/AdministradorProyectosTP/README
@@ -28,9 +28,10 @@ Alcance de esta entrega:
 
 CRUD completo de Tarea (alta, baja, modificación, consulta, listado)
 CRUD de Proyecto y Empleado
-Las tareas se vinculan a un proyecto y un empleado con costo por hora
+Las tareas se vinculan a un proyecto y opcionalmente a un empleado con costo por hora
 
 Se añadieron campos de inicio y fin de sprint y un estado para cada tarea.
+Las fechas se ingresan en formato AAAA-MM-DD.
 Se incluyó un tablero Kanban donde es posible mover las tareas entre
 estados mediante doble clic.
 

--- a/AdministradorProyectosTP/src/dao/jdbc/JdbcTareaDAO.java
+++ b/AdministradorProyectosTP/src/dao/jdbc/JdbcTareaDAO.java
@@ -49,7 +49,10 @@ public class JdbcTareaDAO implements TareaDAO {
                 ps.setNull(6, Types.DATE);
             ps.setString(7, t.getEstado() != null ? t.getEstado().name() : null);
             ps.setInt(8, t.getProyecto().getId());
-            ps.setInt(9, t.getEmpleado().getId());
+            if (t.getEmpleado() != null)
+                ps.setInt(9, t.getEmpleado().getId());
+            else
+                ps.setNull(9, Types.INTEGER);
             ps.setInt(10, t.getCostoHora());
             ps.executeUpdate();
 
@@ -81,7 +84,10 @@ public class JdbcTareaDAO implements TareaDAO {
                 ps.setNull(6, Types.DATE);
             ps.setString(7, t.getEstado() != null ? t.getEstado().name() : null);
             ps.setInt(8, t.getProyecto().getId());
-            ps.setInt(9, t.getEmpleado().getId());
+            if (t.getEmpleado() != null)
+                ps.setInt(9, t.getEmpleado().getId());
+            else
+                ps.setNull(9, Types.INTEGER);
             ps.setInt(10, t.getCostoHora());
             ps.setInt(11, t.getId());
             ps.executeUpdate();
@@ -164,15 +170,19 @@ public class JdbcTareaDAO implements TareaDAO {
 
     private Tarea mapRow(ResultSet rs) throws SQLException {
         int proyectoId = rs.getInt("proyecto_id");
-        int empleadoId = rs.getInt("empleado_id");
+        Integer empleadoId = rs.getObject("empleado_id") != null ? rs.getInt("empleado_id") : null;
 
         Proyecto proyecto;
         Empleado empleado;
         try {
             proyecto = proyectoDao.obtenerPorId(proyectoId)
                     .orElse(new Proyecto(proyectoId, ""));
-            empleado = empleadoDao.obtenerPorId(empleadoId)
-                    .orElse(new Empleado(empleadoId, "", rs.getInt("costo_hora")));
+            if (empleadoId != null) {
+                empleado = empleadoDao.obtenerPorId(empleadoId)
+                        .orElse(new Empleado(empleadoId, "", rs.getInt("costo_hora")));
+            } else {
+                empleado = null;
+            }
         } catch (DAOException e) {
             throw new SQLException("Error obteniendo referencias", e);
         }

--- a/AdministradorProyectosTP/src/service/ReporteServiceImpl.java
+++ b/AdministradorProyectosTP/src/service/ReporteServiceImpl.java
@@ -24,7 +24,7 @@ public class ReporteServiceImpl implements ReporteService {
             for (Tarea t : tareas) {
                 CostoProyecto c = map.computeIfAbsent(t.getProyecto().getId(), k -> new CostoProyecto(k,0,0));
                 c.horas += t.getHorasReales();
-                c.costo += t.getHorasReales() * t.getEmpleado().getCostoHora();
+                c.costo += t.getHorasReales() * t.getCostoHora();
             }
             return new ArrayList<>(map.values());
         } catch (DAOException e) {

--- a/AdministradorProyectosTP/src/service/TareaService.java
+++ b/AdministradorProyectosTP/src/service/TareaService.java
@@ -10,12 +10,12 @@ public interface TareaService {
 
     void alta(String titulo, String desc, int hEst, int hReal,
               LocalDate inicio, LocalDate fin, model.EstadoTarea estado,
-              int proyectoId, int empleadoId)
+              int proyectoId, Integer empleadoId)
             throws ValidacionException, ServiceException;
 
     void modificar(int id, String titulo, String desc, int hEst, int hReal,
                    LocalDate inicio, LocalDate fin, model.EstadoTarea estado,
-                   int proyectoId, int empleadoId)
+                   int proyectoId, Integer empleadoId)
             throws ValidacionException, ServiceException;
 
     void cambiarEstado(int id, model.EstadoTarea estado) throws ServiceException;

--- a/AdministradorProyectosTP/src/service/TareaServiceImpl.java
+++ b/AdministradorProyectosTP/src/service/TareaServiceImpl.java
@@ -35,15 +35,18 @@ public class TareaServiceImpl implements TareaService {
     @Override
     public void alta(String titulo, String desc, int hEst, int hReal,
                      LocalDate inicio, LocalDate fin, model.EstadoTarea estado,
-                     int proyectoId, int empleadoId)
+                     int proyectoId, Integer empleadoId)
             throws ValidacionException, ServiceException {
 
         ValidadorDeErrores.validarTarea(titulo, hEst, hReal);
         try {
             Proyecto proyecto = proyectoDao.obtenerPorId(proyectoId)
                     .orElseThrow(() -> new ServiceException("Proyecto inexistente"));
-            Empleado empleado = empleadoDao.obtenerPorId(empleadoId)
-                    .orElseThrow(() -> new ServiceException("Empleado inexistente"));
+            Empleado empleado = null;
+            if (empleadoId != null) {
+                empleado = empleadoDao.obtenerPorId(empleadoId)
+                        .orElseThrow(() -> new ServiceException("Empleado inexistente"));
+            }
 
             Tarea t = new Tarea(0, titulo, desc, hEst, hReal,
                                 inicio, fin, estado,
@@ -59,7 +62,7 @@ public class TareaServiceImpl implements TareaService {
     @Override
     public void modificar(int id, String titulo, String desc, int hEst, int hReal,
                           LocalDate inicio, LocalDate fin, model.EstadoTarea estado,
-                          int proyectoId, int empleadoId)
+                          int proyectoId, Integer empleadoId)
             throws ValidacionException, ServiceException {
 
         ValidadorDeErrores.validarTarea(titulo, hEst, hReal);
@@ -67,8 +70,11 @@ public class TareaServiceImpl implements TareaService {
             Tarea previa = dao.obtenerPorId(id).orElse(null);
             Proyecto proyecto = proyectoDao.obtenerPorId(proyectoId)
                     .orElseThrow(() -> new ServiceException("Proyecto inexistente"));
-            Empleado empleado = empleadoDao.obtenerPorId(empleadoId)
-                    .orElseThrow(() -> new ServiceException("Empleado inexistente"));
+            Empleado empleado = null;
+            if (empleadoId != null) {
+                empleado = empleadoDao.obtenerPorId(empleadoId)
+                        .orElseThrow(() -> new ServiceException("Empleado inexistente"));
+            }
 
             dao.actualizar(new Tarea(id, titulo, desc, hEst, hReal,
                                      inicio, fin, estado,

--- a/AdministradorProyectosTP/src/ui/TareaPanel.java
+++ b/AdministradorProyectosTP/src/ui/TareaPanel.java
@@ -57,7 +57,9 @@ public class TareaPanel extends AbstractCrudPanel<model.Tarea> {
                 t.getId(), t.getTitulo(),
                 t.getHorasEstimadas(), t.getHorasReales(),
                 t.getEstado(),
-                t.getProyecto().getId(), t.getEmpleado().getId(), t.getCostoHora()
+                t.getProyecto().getId(),
+                t.getEmpleado() != null ? t.getEmpleado().getId() : "",
+                t.getCostoHora()
         };
     }
 
@@ -113,7 +115,7 @@ public class TareaPanel extends AbstractCrudPanel<model.Tarea> {
                 java.time.LocalDate fin    = campos.getFinSprint();
                 model.EstadoTarea estado   = campos.getEstado();
                 int proyecto  = campos.getProyectoId();
-                int empleado  = campos.getEmpleadoId();
+                Integer empleado  = campos.getEmpleadoId();
                 if (existente == null) {
                     service.alta(titulo, desc, est, real, inicio, fin, estado, proyecto, empleado);
                 } else {

--- a/AdministradorProyectosTP/src/ui/form/CamposTareaPanel.java
+++ b/AdministradorProyectosTP/src/ui/form/CamposTareaPanel.java
@@ -26,8 +26,8 @@ public class CamposTareaPanel extends CamposPanel {
                 .add("Descripción:", descTxt)
                 .add("Horas Estimadas:", estTxt)
                 .add("Horas Reales:", realTxt)
-                .add("Inicio Sprint:", inicioTxt)
-                .add("Fin Sprint:", finTxt)
+                .add("Inicio Sprint (AAAA-MM-DD):", inicioTxt)
+                .add("Fin Sprint (AAAA-MM-DD):", finTxt)
                 .add("Proyecto ID:", proyectoTxt)
                 .add("Empleado ID:", empleadoTxt)
                 .add("Estado:", estadoBox)
@@ -46,7 +46,8 @@ public class CamposTareaPanel extends CamposPanel {
             if (existente.getEstado() != null)
                 estadoBox.setSelectedItem(existente.getEstado());
             proyectoTxt.setText(String.valueOf(existente.getProyecto().getId()));
-            empleadoTxt.setText(String.valueOf(existente.getEmpleado().getId()));
+            if (existente.getEmpleado() != null)
+                empleadoTxt.setText(String.valueOf(existente.getEmpleado().getId()));
         }
         if (historial != null) {
             for (model.HistorialEstado h : historial) {
@@ -71,5 +72,7 @@ public class CamposTareaPanel extends CamposPanel {
     }
     public model.EstadoTarea getEstado() { return (model.EstadoTarea) estadoBox.getSelectedItem(); }
     public int getProyectoId() { return Integer.parseInt(proyectoTxt.getText()); }
-    public int getEmpleadoId() { return Integer.parseInt(empleadoTxt.getText()); }
+    public Integer getEmpleadoId() {
+        return empleadoTxt.getText().isBlank() ? null : Integer.parseInt(empleadoTxt.getText());
+    }
 }


### PR DESCRIPTION
## Summary
- make employee optional when creating or editing a task
- clarify date format in the form and README
- handle missing employee in DAO, services and UI

## Testing
- `javac -d bin $(find src -name '*.java')`
- `java -cp bin main.Main` *(fails: `No suitable driver found`)*

------
https://chatgpt.com/codex/tasks/task_e_687596819a98833381271ab7cc240306