### PR TITLE
Use objects for tasks

### DIFF
--- a/AdministradorProyectosTP/src/app/AppManager.java
+++ b/AdministradorProyectosTP/src/app/AppManager.java
@@ -42,7 +42,7 @@ public final class AppManager {
     public void initPanels(TareaService ts, ProyectoService ps,
                            EmpleadoService es, AsignacionService as,
                            ReporteService rs) {
-        tareaPanel = new TareaPanel(this, ts);
+        tareaPanel = new TareaPanel(this, ts, ps, es);
         proyectoPanel = new ProyectoPanel(this, ps);
         empleadoPanel = new EmpleadoPanel(this, es);
         asignacionPanel = new AsignacionPanel(this, as, ps);

--- a/AdministradorProyectosTP/src/main/Main.java
+++ b/AdministradorProyectosTP/src/main/Main.java
@@ -28,7 +28,7 @@ public class Main {
         HistorialDAO histDao    = new JdbcHistorialDAO(c);
         AsignacionDAO asigDao   = new JdbcAsignacionDAO(c);
 
-        TareaService tareaSvc      = new TareaServiceImpl(tareaDao, histDao, proyectoDao, empleadoDao);
+        TareaService tareaSvc      = new TareaServiceImpl(tareaDao, histDao);
         ProyectoService projSvc    = new ProyectoServiceImpl(proyectoDao);
         EmpleadoService empSvc     = new EmpleadoServiceImpl(empleadoDao);
         AsignacionService asigSvc  = new AsignacionServiceImpl(asigDao, empleadoDao);

--- a/AdministradorProyectosTP/src/service/TareaService.java
+++ b/AdministradorProyectosTP/src/service/TareaService.java
@@ -10,12 +10,12 @@ public interface TareaService {
 
     void alta(String titulo, String desc, int hEst, int hReal,
               LocalDate inicio, LocalDate fin, model.EstadoTarea estado,
-              int proyectoId, Integer empleadoId)
+              model.Proyecto proyecto, model.Empleado empleado)
             throws ValidacionException, ServiceException;
 
     void modificar(int id, String titulo, String desc, int hEst, int hReal,
                    LocalDate inicio, LocalDate fin, model.EstadoTarea estado,
-                   int proyectoId, Integer empleadoId)
+                   model.Proyecto proyecto, model.Empleado empleado)
             throws ValidacionException, ServiceException;
 
     void cambiarEstado(int id, model.EstadoTarea estado) throws ServiceException;

--- a/AdministradorProyectosTP/src/service/TareaServiceImpl.java
+++ b/AdministradorProyectosTP/src/service/TareaServiceImpl.java
@@ -3,8 +3,6 @@ package service;
 import dao.DAOException;
 import dao.TareaDAO;
 import dao.HistorialDAO;
-import dao.ProyectoDAO;
-import dao.EmpleadoDAO;
 import model.Tarea;
 import model.Proyecto;
 import model.Empleado;
@@ -19,15 +17,10 @@ public class TareaServiceImpl implements TareaService {
 
     private final TareaDAO dao;
     private final HistorialDAO historialDao;
-    private final ProyectoDAO proyectoDao;
-    private final EmpleadoDAO empleadoDao;
 
-    public TareaServiceImpl(TareaDAO dao, HistorialDAO historialDao,
-                            ProyectoDAO proyectoDao, EmpleadoDAO empleadoDao) {
+    public TareaServiceImpl(TareaDAO dao, HistorialDAO historialDao) {
         this.dao = dao;
         this.historialDao = historialDao;
-        this.proyectoDao = proyectoDao;
-        this.empleadoDao = empleadoDao;
     }
 
     // ------------------------------------ CRUD
@@ -35,19 +28,11 @@ public class TareaServiceImpl implements TareaService {
     @Override
     public void alta(String titulo, String desc, int hEst, int hReal,
                      LocalDate inicio, LocalDate fin, model.EstadoTarea estado,
-                     int proyectoId, Integer empleadoId)
+                     model.Proyecto proyecto, model.Empleado empleado)
             throws ValidacionException, ServiceException {
 
         ValidadorDeErrores.validarTarea(titulo, hEst, hReal);
         try {
-            Proyecto proyecto = proyectoDao.obtenerPorId(proyectoId)
-                    .orElseThrow(() -> new ServiceException("Proyecto inexistente"));
-            Empleado empleado = null;
-            if (empleadoId != null) {
-                empleado = empleadoDao.obtenerPorId(empleadoId)
-                        .orElseThrow(() -> new ServiceException("Empleado inexistente"));
-            }
-
             Tarea t = new Tarea(0, titulo, desc, hEst, hReal,
                                 inicio, fin, estado,
                                 proyecto, empleado);
@@ -62,19 +47,12 @@ public class TareaServiceImpl implements TareaService {
     @Override
     public void modificar(int id, String titulo, String desc, int hEst, int hReal,
                           LocalDate inicio, LocalDate fin, model.EstadoTarea estado,
-                          int proyectoId, Integer empleadoId)
+                          model.Proyecto proyecto, model.Empleado empleado)
             throws ValidacionException, ServiceException {
 
         ValidadorDeErrores.validarTarea(titulo, hEst, hReal);
         try {
             Tarea previa = dao.obtenerPorId(id).orElse(null);
-            Proyecto proyecto = proyectoDao.obtenerPorId(proyectoId)
-                    .orElseThrow(() -> new ServiceException("Proyecto inexistente"));
-            Empleado empleado = null;
-            if (empleadoId != null) {
-                empleado = empleadoDao.obtenerPorId(empleadoId)
-                        .orElseThrow(() -> new ServiceException("Empleado inexistente"));
-            }
 
             dao.actualizar(new Tarea(id, titulo, desc, hEst, hReal,
                                      inicio, fin, estado,

--- a/AdministradorProyectosTP/src/ui/KanbanPanel.java
+++ b/AdministradorProyectosTP/src/ui/KanbanPanel.java
@@ -2,6 +2,8 @@ package ui;
 
 import app.AppManager;
 import service.TareaService;
+import service.ProyectoService;
+import service.EmpleadoService;
 import service.ServiceException;
 
 import javax.swing.*;
@@ -12,13 +14,18 @@ import ui.componentes.Dialogs;
 public class KanbanPanel extends JPanel {
     private final AppManager manager;
     private final TareaService service;
+    private final ProyectoService proyectoService;
+    private final EmpleadoService empleadoService;
     private final DefaultListModel<model.Tarea> backlogModel = new DefaultListModel<>();
     private final DefaultListModel<model.Tarea> progresoModel = new DefaultListModel<>();
     private final DefaultListModel<model.Tarea> doneModel = new DefaultListModel<>();
 
-    public KanbanPanel(AppManager manager, TareaService service) {
+    public KanbanPanel(AppManager manager, TareaService service,
+                       ProyectoService proyectoService, EmpleadoService empleadoService) {
         this.manager = manager;
         this.service = service;
+        this.proyectoService = proyectoService;
+        this.empleadoService = empleadoService;
         setLayout(new BorderLayout(10,10));
 
         JPanel board = new JPanel(new GridLayout(1,3,10,10));
@@ -31,7 +38,7 @@ public class KanbanPanel extends JPanel {
         volver.addActionListener(new java.awt.event.ActionListener() {
             @Override
             public void actionPerformed(java.awt.event.ActionEvent e) {
-                manager.mostrar(new TareaPanel(manager, service));
+                manager.mostrar(new TareaPanel(manager, service, proyectoService, empleadoService));
             }
         });
         add(volver, BorderLayout.SOUTH);

--- a/AdministradorProyectosTP/src/ui/form/CamposTareaPanel.java
+++ b/AdministradorProyectosTP/src/ui/form/CamposTareaPanel.java
@@ -15,11 +15,12 @@ public class CamposTareaPanel extends CamposPanel {
     private final JTextField inicioTxt = new JTextField();
     private final JTextField finTxt = new JTextField();
     private final JComboBox<model.EstadoTarea> estadoBox = new JComboBox<>(model.EstadoTarea.values());
-    private final JTextField proyectoTxt = new JTextField();
-    private final JTextField empleadoTxt = new JTextField();
+    private final JComboBox<model.Proyecto> proyectoBox = new JComboBox<>();
+    private final JComboBox<model.Empleado> empleadoBox = new JComboBox<>();
     private final JTextArea histArea = new JTextArea();
 
-    public CamposTareaPanel(model.Tarea existente, List<model.HistorialEstado> historial) {
+    public CamposTareaPanel(model.Tarea existente, List<model.HistorialEstado> historial,
+                            List<model.Proyecto> proyectos, List<model.Empleado> empleados) {
         histArea.setEditable(false);
         FormBuilder b = new FormBuilder()
                 .add("Título:", tituloTxt)
@@ -28,12 +29,28 @@ public class CamposTareaPanel extends CamposPanel {
                 .add("Horas Reales:", realTxt)
                 .add("Inicio Sprint (AAAA-MM-DD):", inicioTxt)
                 .add("Fin Sprint (AAAA-MM-DD):", finTxt)
-                .add("Proyecto ID:", proyectoTxt)
-                .add("Empleado ID:", empleadoTxt)
+                .add("Proyecto:", proyectoBox)
+                .add("Empleado:", empleadoBox)
                 .add("Estado:", estadoBox)
                 .add("Historial:", new JScrollPane(histArea));
         setLayout(new BorderLayout());
         add(b.build(), BorderLayout.CENTER);
+        if (proyectos != null) {
+            for (model.Proyecto p : proyectos) proyectoBox.addItem(p);
+        }
+        if (empleados != null) {
+            empleadoBox.addItem(null); // opción sin asignar
+            for (model.Empleado e : empleados) empleadoBox.addItem(e);
+            empleadoBox.setRenderer(new DefaultListCellRenderer() {
+                @Override
+                public java.awt.Component getListCellRendererComponent(JList<?> list, Object value, int index,
+                                                                      boolean isSelected, boolean cellHasFocus) {
+                    super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
+                    setText(value == null ? "" : value.toString());
+                    return this;
+                }
+            });
+        }
         if (existente != null) {
             tituloTxt.setText(existente.getTitulo());
             descTxt.setText(existente.getDescripcion());
@@ -45,9 +62,9 @@ public class CamposTareaPanel extends CamposPanel {
                 finTxt.setText(existente.getFinSprint().toString());
             if (existente.getEstado() != null)
                 estadoBox.setSelectedItem(existente.getEstado());
-            proyectoTxt.setText(String.valueOf(existente.getProyecto().getId()));
+            proyectoBox.setSelectedItem(existente.getProyecto());
             if (existente.getEmpleado() != null)
-                empleadoTxt.setText(String.valueOf(existente.getEmpleado().getId()));
+                empleadoBox.setSelectedItem(existente.getEmpleado());
         }
         if (historial != null) {
             for (model.HistorialEstado h : historial) {
@@ -56,8 +73,8 @@ public class CamposTareaPanel extends CamposPanel {
         }
     }
 
-    public CamposTareaPanel() {
-        this(null, null);
+    public CamposTareaPanel(List<model.Proyecto> proyectos, List<model.Empleado> empleados) {
+        this(null, null, proyectos, empleados);
     }
 
     public String getTitulo() { return tituloTxt.getText(); }
@@ -71,8 +88,6 @@ public class CamposTareaPanel extends CamposPanel {
         return finTxt.getText().isBlank() ? null : LocalDate.parse(finTxt.getText());
     }
     public model.EstadoTarea getEstado() { return (model.EstadoTarea) estadoBox.getSelectedItem(); }
-    public int getProyectoId() { return Integer.parseInt(proyectoTxt.getText()); }
-    public Integer getEmpleadoId() {
-        return empleadoTxt.getText().isBlank() ? null : Integer.parseInt(empleadoTxt.getText());
-    }
+    public model.Proyecto getProyecto() { return (model.Proyecto) proyectoBox.getSelectedItem(); }
+    public model.Empleado getEmpleado() { return (model.Empleado) empleadoBox.getSelectedItem(); }
 }


### PR DESCRIPTION
## Summary
- update `TareaService` signatures to receive `Proyecto` and `Empleado`
- simplify `TareaServiceImpl` by removing lookups
- let users choose projects and employees with combo boxes
- wire panel constructors through `AppManager` and `KanbanPanel`
- adapt `Main` to new service constructor

## Testing
- `javac -d bin $(find src -name '*.java')`

------
https://chatgpt.com/codex/tasks/task_e_6877cabba3b0833382d3fa8a2d76e9f0