### PR TITLE
Store Tarea reference in history

### DIFF
--- a/AdministradorProyectosTP/src/dao/jdbc/JdbcHistorialDAO.java
+++ b/AdministradorProyectosTP/src/dao/jdbc/JdbcHistorialDAO.java
@@ -2,6 +2,8 @@ package dao.jdbc;
 
 import dao.DAOException;
 import dao.HistorialDAO;
+import dao.TareaDAO;
+import model.Tarea;
 import model.EstadoTarea;
 import model.HistorialEstado;
 
@@ -12,9 +14,11 @@ import java.util.List;
 
 public class JdbcHistorialDAO implements HistorialDAO {
     private final Connection conn;
+    private final TareaDAO tareaDao;
 
-    public JdbcHistorialDAO(Connection conn) throws DAOException {
+    public JdbcHistorialDAO(Connection conn, TareaDAO tareaDao) throws DAOException {
         this.conn = conn;
+        this.tareaDao = tareaDao;
         try {
             crearTabla();
         } catch (SQLException e) {
@@ -72,9 +76,17 @@ public class JdbcHistorialDAO implements HistorialDAO {
     }
 
     private HistorialEstado mapRow(ResultSet rs) throws SQLException {
+        int tareaId = rs.getInt("tarea_id");
+        Tarea tarea;
+        try {
+            tarea = tareaDao.obtenerPorId(tareaId)
+                    .orElse(new Tarea(tareaId, "", "", 0, 0, null, null, null, null, null));
+        } catch (DAOException e) {
+            throw new SQLException("Error obteniendo tarea", e);
+        }
         return new HistorialEstado(
                 rs.getInt("id"),
-                rs.getInt("tarea_id"),
+                tarea,
                 EstadoTarea.valueOf(rs.getString("estado")),
                 rs.getString("responsable"),
                 rs.getTimestamp("fecha").toLocalDateTime()

--- a/AdministradorProyectosTP/src/main/Main.java
+++ b/AdministradorProyectosTP/src/main/Main.java
@@ -25,7 +25,7 @@ public class Main {
         ProyectoDAO proyectoDao = new JdbcProyectoDAO(c);
         EmpleadoDAO empleadoDao = new JdbcEmpleadoDAO(c);
         TareaDAO tareaDao      = new JdbcTareaDAO(c, proyectoDao, empleadoDao);
-        HistorialDAO histDao    = new JdbcHistorialDAO(c);
+        HistorialDAO histDao    = new JdbcHistorialDAO(c, tareaDao);
         AsignacionDAO asigDao   = new JdbcAsignacionDAO(c);
 
         TareaService tareaSvc      = new TareaServiceImpl(tareaDao, histDao, proyectoDao, empleadoDao);

--- a/AdministradorProyectosTP/src/model/HistorialEstado.java
+++ b/AdministradorProyectosTP/src/model/HistorialEstado.java
@@ -1,29 +1,31 @@
 package model;
 
 import java.time.LocalDateTime;
+import model.Tarea;
 
 public class HistorialEstado {
     private int id;
-    private int tareaId;
+    private Tarea tarea;
     private EstadoTarea estado;
     private String responsable;
     private LocalDateTime fecha;
 
-    public HistorialEstado(int id, int tareaId, EstadoTarea estado, String responsable, LocalDateTime fecha) {
+    public HistorialEstado(int id, Tarea tarea, EstadoTarea estado, String responsable, LocalDateTime fecha) {
         this.id = id;
-        this.tareaId = tareaId;
+        this.tarea = tarea;
         this.estado = estado;
         this.responsable = responsable;
         this.fecha = fecha;
     }
 
-    public HistorialEstado(int tareaId, EstadoTarea estado, String responsable, LocalDateTime fecha) {
-        this(0, tareaId, estado, responsable, fecha);
+    public HistorialEstado(Tarea tarea, EstadoTarea estado, String responsable, LocalDateTime fecha) {
+        this(0, tarea, estado, responsable, fecha);
     }
 
     public int getId() { return id; }
     public void setId(int id) { this.id = id; }
-    public int getTareaId() { return tareaId; }
+    public Tarea getTarea() { return tarea; }
+    public int getTareaId() { return tarea != null ? tarea.getId() : 0; }
     public EstadoTarea getEstado() { return estado; }
     public String getResponsable() { return responsable; }
     public LocalDateTime getFecha() { return fecha; }

--- a/AdministradorProyectosTP/src/service/TareaServiceImpl.java
+++ b/AdministradorProyectosTP/src/service/TareaServiceImpl.java
@@ -53,7 +53,7 @@ public class TareaServiceImpl implements TareaService {
                                 proyecto, empleado);
             dao.crear(t);
             if(estado != null)
-                historialDao.registrar(new HistorialEstado(t.getId(), estado, "creacion", java.time.LocalDateTime.now()));
+                historialDao.registrar(new HistorialEstado(t, estado, "creacion", java.time.LocalDateTime.now()));
         } catch (DAOException ex) {
             throw new ServiceException("No se pudo guardar la tarea", ex);
         }
@@ -76,11 +76,12 @@ public class TareaServiceImpl implements TareaService {
                         .orElseThrow(() -> new ServiceException("Empleado inexistente"));
             }
 
-            dao.actualizar(new Tarea(id, titulo, desc, hEst, hReal,
-                                     inicio, fin, estado,
-                                     proyecto, empleado));
+            Tarea actualizada = new Tarea(id, titulo, desc, hEst, hReal,
+                                         inicio, fin, estado,
+                                         proyecto, empleado);
+            dao.actualizar(actualizada);
             if(previa != null && previa.getEstado() != estado)
-                historialDao.registrar(new HistorialEstado(id, estado, "modificacion", java.time.LocalDateTime.now()));
+                historialDao.registrar(new HistorialEstado(actualizada, estado, "modificacion", java.time.LocalDateTime.now()));
         } catch (DAOException ex) {
             throw new ServiceException("No se pudo actualizar la tarea", ex);
         }
@@ -90,7 +91,9 @@ public class TareaServiceImpl implements TareaService {
     public void cambiarEstado(int id, model.EstadoTarea estado) throws ServiceException {
         try {
             dao.actualizarEstado(id, estado);
-            historialDao.registrar(new HistorialEstado(id, estado, "cambio", java.time.LocalDateTime.now()));
+            Tarea t = dao.obtenerPorId(id)
+                    .orElse(new Tarea(id, "", "", 0, 0, null, null, estado, null, null));
+            historialDao.registrar(new HistorialEstado(t, estado, "cambio", java.time.LocalDateTime.now()));
         } catch (DAOException ex) {
             throw new ServiceException("No se pudo cambiar el estado", ex);
         }


### PR DESCRIPTION
## Summary
- keep a `Tarea` object inside `HistorialEstado`
- load the referenced task when mapping JDBC rows
- pass `Tarea` instances from the service when recording history
- update `Main` to supply `TareaDAO` to `JdbcHistorialDAO`

## Testing
- `javac -d bin @sources.txt`

------
https://chatgpt.com/codex/tasks/task_e_6877cab2482c8333b9715c84a0bdb765