### PR TITLE
Improve error handling for missing tasks

### DIFF
--- a/AdministradorProyectosTP/src/dao/jdbc/JdbcHistorialDAO.java
+++ b/AdministradorProyectosTP/src/dao/jdbc/JdbcHistorialDAO.java
@@ -80,7 +80,7 @@ public class JdbcHistorialDAO implements HistorialDAO {
         Tarea tarea;
         try {
             tarea = tareaDao.obtenerPorId(tareaId)
-                    .orElse(new Tarea(tareaId, "", "", 0, 0, null, null, null, null, null));
+                    .orElseThrow(() -> new SQLException("Tarea " + tareaId + " inexistente"));
         } catch (DAOException e) {
             throw new SQLException("Error obteniendo tarea", e);
         }

--- a/AdministradorProyectosTP/src/service/TareaServiceImpl.java
+++ b/AdministradorProyectosTP/src/service/TareaServiceImpl.java
@@ -70,7 +70,7 @@ public class TareaServiceImpl implements TareaService {
         try {
             dao.actualizarEstado(id, estado);
             Tarea t = dao.obtenerPorId(id)
-                    .orElse(new Tarea(id, "", "", 0, 0, null, null, estado, null, null));
+                    .orElseThrow(() -> new ServiceException("Tarea no encontrada"));
             historialDao.registrar(new HistorialEstado(t, estado, "cambio", java.time.LocalDateTime.now()));
         } catch (DAOException ex) {
             throw new ServiceException("No se pudo cambiar el estado", ex);

--- a/AdministradorProyectosTP/src/ui/KanbanPanel.java
+++ b/AdministradorProyectosTP/src/ui/KanbanPanel.java
@@ -72,7 +72,7 @@ public class KanbanPanel extends JPanel {
             service.cambiarEstado(t.getId(), nuevo);
             cargarDatos();
         } catch (ServiceException ex) {
-            Dialogs.error(this, "No se pudo mover la tarea");
+            Dialogs.error(this, ex.getMessage());
         }
     }
 


### PR DESCRIPTION
## Summary
- throw an exception when an associated task is missing in `JdbcHistorialDAO`
- propagate missing-task errors from `TareaServiceImpl.cambiarEstado`
- show service exception messages in `KanbanPanel`

## Testing
- `javac -d bin @sources.txt`

------
https://chatgpt.com/codex/tasks/task_e_687e877e3a4c833383c425e55c57e89e